### PR TITLE
Removing prop-types from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "prop-types": "^15.5.4",
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"
   },


### PR DESCRIPTION
This addresses #2, but should not be merged until #6 is because that PR cleans up the existing use of prop-types.  At that point, running `flow` will verify that this will not break anything.