### PR TITLE
Fix issue, add router, export flow types, add login and register pages.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-router-dom": "^4.2.2",
     "tabler-react": "link:..",
     "react-scripts": "^1.1.1"
   },

--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "watch": "react-scripts start --watch",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"

--- a/example/src/App.react.js
+++ b/example/src/App.react.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from "react";
+import { BrowserRouter as Router, Route } from "react-router-dom";
 
 import "./App.css";
 import ForgotPasswordPage from "./ForgotPasswordPage.react";
@@ -9,9 +10,11 @@ type Props = {||};
 
 function App(props: Props): React.Node {
   return (
-    <div className="page">
-      <ForgotPasswordPage />
-    </div>
+    <Router basename={process.env.PUBLIC_URL}>
+      <div className="page">
+        <Route exact path="/forgot-password" component={ForgotPasswordPage} />
+      </div>
+    </Router>
   );
 }
 

--- a/example/src/App.react.js
+++ b/example/src/App.react.js
@@ -3,17 +3,22 @@
 import * as React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 
-import "./App.css";
 import ForgotPasswordPage from "./ForgotPasswordPage.react";
+import LoginPage from "./LoginPage.react";
+import RegisterPage from "./RegisterPage.react";
+
+import "./App.css";
 
 type Props = {||};
 
 function App(props: Props): React.Node {
   return (
     <Router basename={process.env.PUBLIC_URL}>
-      <div className="page">
+      <React.Fragment>
         <Route exact path="/forgot-password" component={ForgotPasswordPage} />
-      </div>
+        <Route exact path="/login" component={LoginPage} />
+        <Route exact path="/register" component={RegisterPage} />
+      </React.Fragment>
     </Router>
   );
 }

--- a/example/src/ForgotPasswordPage.react.js
+++ b/example/src/ForgotPasswordPage.react.js
@@ -9,7 +9,12 @@ type Props = {||};
 function ForgotPasswordPage(props: Props): React.Node {
   return (
     <StandaloneFormPage>
-      <Form action="" method="get" title="Forgot Password">
+      <Form
+        action=""
+        buttonText="Request Password Change"
+        method="get"
+        title="Forgot Password"
+      >
         <p className="text-muted">
           Enter your email address and your password will be reset and emailed
           to you.

--- a/example/src/ForgotPasswordPage.react.js
+++ b/example/src/ForgotPasswordPage.react.js
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-import { Form, FormTextInput, StandaloneFormPage } from 'tabler-react';
+import { Form, FormTextInput, StandaloneFormPage } from "tabler-react";
 
 type Props = {||};
 

--- a/example/src/LoginPage.react.js
+++ b/example/src/LoginPage.react.js
@@ -1,0 +1,24 @@
+// @flow
+
+import * as React from "react";
+
+import { Form, FormTextInput, StandaloneFormPage } from "tabler-react";
+
+type Props = {||};
+
+function LoginPage(props: Props): React.Node {
+  return (
+    <StandaloneFormPage>
+      <Form action="" method="get" title="Login to your Account">
+        <FormTextInput label="Email Address" placeHolder="Enter email" />
+        <FormTextInput
+          type="password"
+          label="Password"
+          placeHolder="Password"
+        />
+      </Form>
+    </StandaloneFormPage>
+  );
+}
+
+export default LoginPage;

--- a/example/src/LoginPage.react.js
+++ b/example/src/LoginPage.react.js
@@ -9,7 +9,12 @@ type Props = {||};
 function LoginPage(props: Props): React.Node {
   return (
     <StandaloneFormPage>
-      <Form action="" method="get" title="Login to your Account">
+      <Form
+        action=""
+        buttonText="Login"
+        method="get"
+        title="Login to your Account"
+      >
         <FormTextInput label="Email Address" placeHolder="Enter email" />
         <FormTextInput
           type="password"

--- a/example/src/RegisterPage.react.js
+++ b/example/src/RegisterPage.react.js
@@ -1,0 +1,31 @@
+// @flow
+
+import * as React from "react";
+
+import {
+  Form,
+  FormTextInput,
+  FormCheckboxInput,
+  StandaloneFormPage
+} from "tabler-react";
+
+type Props = {||};
+
+function RegisterPage(props: Props): React.Node {
+  return (
+    <StandaloneFormPage>
+      <Form action="" method="get" title="Create New Account">
+        <FormTextInput label="Name" placeHolder="Enter name" />
+        <FormTextInput label="Email Address" placeHolder="Enter email" />
+        <FormTextInput
+          isPassword={true}
+          label="Password"
+          placeHolder="Password"
+        />
+        <FormCheckboxInput label="Agree to the terms and policy" />
+      </Form>
+    </StandaloneFormPage>
+  );
+}
+
+export default RegisterPage;

--- a/example/src/RegisterPage.react.js
+++ b/example/src/RegisterPage.react.js
@@ -14,11 +14,16 @@ type Props = {||};
 function RegisterPage(props: Props): React.Node {
   return (
     <StandaloneFormPage>
-      <Form action="" method="get" title="Create New Account">
+      <Form
+        action=""
+        buttonText="Create Account"
+        method="get"
+        title="Create New Account"
+      >
         <FormTextInput label="Name" placeHolder="Enter name" />
         <FormTextInput label="Email Address" placeHolder="Enter email" />
         <FormTextInput
-          isPassword={true}
+          type="password"
           label="Password"
           placeHolder="Password"
         />

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1436,6 +1436,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
@@ -3172,6 +3176,16 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3187,6 +3201,10 @@ hoek@2.x.x:
 hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
+
+hoist-non-react-statics@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3427,7 +3445,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.2:
+invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -4317,7 +4335,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4998,7 +5016,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
+path-to-regexp@^1.0.1, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -5424,7 +5442,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -5587,6 +5605,29 @@ react-dom@^16.2.0:
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
+
+react-router-dom@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
+  dependencies:
+    history "^4.7.2"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.4"
+    react-router "^4.2.0"
+    warning "^3.0.0"
+
+react-router@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.2.0.tgz#61f7b3e3770daeb24062dae3eedef1b054155986"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.3.0"
+    invariant "^2.2.2"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.4"
+    warning "^3.0.0"
 
 react-scripts@^1.1.1:
   version "1.1.4"
@@ -5926,6 +5967,10 @@ resolve-from@^1.0.0:
 resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -6904,6 +6949,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -6931,6 +6980,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.10.0:
   version "0.10.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "precommit": "pretty-quick --staged",
     "format": "prettier --write \"**/*.js\""
   },
-  "dependencies": {},
+  "dependencies": {
+    "classnames": "^2.2.5"
+  },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
     "react-dom": "^15.0.0 || ^16.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
-    "build": "rollup -c",
+    "build": "rollup -c && flow-copy-source -v src dist",
     "start": "rollup -c -w",
     "prepare": "yarn run build",
     "predeploy": "cd example && yarn install && yarn run build",
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^7.7.0",
     "eslint-plugin-standard": "^3.0.1",
     "flow-bin": "^0.69.0",
+    "flow-copy-source": "^1.3.0",
     "gh-pages": "^1.1.0",
     "husky": "^0.14.3",
     "prettier": "1.12.0",

--- a/src/components/Alert/Alert.react.js
+++ b/src/components/Alert/Alert.react.js
@@ -17,7 +17,7 @@ type Props = {|
   +icon?: string,
   +extraSpace?: boolean,
   +dismissible?: boolean,
-  +avatar?: string,
+  +avatar?: string
 |};
 
 function Alert({
@@ -47,7 +47,7 @@ function Alert({
       "alert-icon": !!icon,
       "mt-5 mb-6": extraSpace,
       "alert-dismissible": dismissible,
-      "alert-avatar": !!avatar,
+      "alert-avatar": !!avatar
     },
     className
   );

--- a/src/components/Alert/AlertLink.react.js
+++ b/src/components/Alert/AlertLink.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function AlertLink({ children, className, ...props }: Props): React.Node {

--- a/src/components/Avatar/Avatar.react.js
+++ b/src/components/Avatar/Avatar.react.js
@@ -14,7 +14,7 @@ type Props = {|
   +status?: "grey" | "red" | "yellow" | "green",
   +placeholder?: boolean,
   +icon?: string,
-  +color?: string,
+  +color?: string
 |};
 
 function Avatar({
@@ -34,7 +34,7 @@ function Avatar({
       avatar: true,
       [`avatar-${size}`]: !!size,
       "avatar-placeholder": placeholder,
-      [`avatar-${color}`]: !!color,
+      [`avatar-${color}`]: !!color
     },
     className
   );
@@ -45,7 +45,7 @@ function Avatar({
         image
           ? Object.assign(
               {
-                backgroundImage: `url(${image})`,
+                backgroundImage: `url(${image})`
               },
               style
             )

--- a/src/components/Avatar/AvatarList.react.js
+++ b/src/components/Avatar/AvatarList.react.js
@@ -6,7 +6,7 @@ import cn from "classnames";
 type Props = {
   +children?: React.Node,
   +className?: string,
-  +stacked?: boolean,
+  +stacked?: boolean
 };
 
 function AvatarList({
@@ -18,7 +18,7 @@ function AvatarList({
   const classes = cn(
     {
       "avatar-list": true,
-      "avatar-list-stacked": stacked,
+      "avatar-list-stacked": stacked
     },
     className
   );

--- a/src/components/Badge/Badge.react.js
+++ b/src/components/Badge/Badge.react.js
@@ -6,14 +6,14 @@ import cn from "classnames";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +value?: string,
+  +value?: string
 |};
 
 function Badge({ className, children, value }: Props): React.Node {
   const classes = cn(
     {
       badge: true,
-      "badge-primary": true,
+      "badge-primary": true
     },
     className
   );

--- a/src/components/Button/Button.react.js
+++ b/src/components/Button/Button.react.js
@@ -26,7 +26,7 @@ type Props = {
   +social?: string,
   +loading?: boolean,
   +toggle?: boolean,
-  +RootComponent?: React.ElementType,
+  +RootComponent?: React.ElementType
 };
 
 const Button = ({
@@ -78,7 +78,7 @@ const Button = ({
       "btn-pill": pill,
       "btn-icon": !children,
       "btn-loading": loading,
-      "dropdown-toggle": toggle,
+      "dropdown-toggle": toggle
     },
     className
   );

--- a/src/components/Button/ButtonList.react.js
+++ b/src/components/Button/ButtonList.react.js
@@ -6,7 +6,7 @@ import cn from "classnames";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +align?: "" | "left" | "center" | "right",
+  +align?: "" | "left" | "center" | "right"
 |};
 
 function ButtonList({

--- a/src/components/Card/Card.react.js
+++ b/src/components/Card/Card.react.js
@@ -11,7 +11,7 @@ type Props = {|
   +className?: string,
   +title?: string,
   +body?: React.Node,
-  +RootComponent?: React.ElementType,
+  +RootComponent?: React.ElementType
 |};
 
 function Card({

--- a/src/components/Card/CardBody.react.js
+++ b/src/components/Card/CardBody.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function CardBody({ className, children, ...props }: Props): React.Node {

--- a/src/components/Card/CardHeader.react.js
+++ b/src/components/Card/CardHeader.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function CardHeader({ className, children, ...props }: Props): React.Node {

--- a/src/components/Card/CardTitle.react.js
+++ b/src/components/Card/CardTitle.react.js
@@ -6,7 +6,7 @@ import cn from "classnames";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +RootComponent?: React.ElementType,
+  +RootComponent?: React.ElementType
 |};
 
 function CardTitle({

--- a/src/components/Code/CodeExample.react.js
+++ b/src/components/Code/CodeExample.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function CodeExample({ className, children, ...props }: Props): React.Node {

--- a/src/components/Code/CodeHighlight.react.js
+++ b/src/components/Code/CodeHighlight.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function CodeHighlight({ className, children, ...props }: Props): React.Node {

--- a/src/components/Code/index.js
+++ b/src/components/Code/index.js
@@ -5,7 +5,7 @@ import CodeHighlight from "./CodeHighlight.react";
 
 const Code = {
   Example: CodeExample,
-  Highlight: CodeHighlight,
+  Highlight: CodeHighlight
 };
 
 export { Code as default };

--- a/src/components/Container.react.js
+++ b/src/components/Container.react.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 function Container(props: Props): React.Node {

--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -10,7 +10,7 @@ import DropdownItemDivider from "./DropdownItemDivider.react";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +desktopOnly?: boolean,
+  +desktopOnly?: boolean
 |};
 
 function Dropdown({

--- a/src/components/Dropdown/DropdownItem.react.js
+++ b/src/components/Dropdown/DropdownItem.react.js
@@ -9,7 +9,7 @@ type Props = {|
   +className?: string,
   +icon?: string,
   +value?: string,
-  +badge?: string,
+  +badge?: string
 |};
 
 function DropdownItem({

--- a/src/components/Dropdown/DropdownItemDivider.react.js
+++ b/src/components/Dropdown/DropdownItemDivider.react.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 function DropdownItemDivider(props: Props): React.Node {

--- a/src/components/Dropdown/DropdownMenu.react.js
+++ b/src/components/Dropdown/DropdownMenu.react.js
@@ -9,7 +9,7 @@ type Props = {|
   +children?: React.Node,
   +className?: string,
   +position?: string,
-  +arrow?: boolean,
+  +arrow?: boolean
 |};
 
 function DropdownMenu({
@@ -23,7 +23,7 @@ function DropdownMenu({
     {
       "dropdown-menu": true,
       [`dropdown-menu-${position}`]: position,
-      [`dropdown-menu-arrow`]: arrow,
+      [`dropdown-menu-arrow`]: arrow
     },
     className
   );

--- a/src/components/Dropdown/DropdownTrigger.react.js
+++ b/src/components/Dropdown/DropdownTrigger.react.js
@@ -7,7 +7,7 @@ type Props = {|
   +children?: React.Node,
   +className?: string,
   +toggle?: boolean,
-  +value?: string,
+  +value?: string
 |};
 
 function DropdownTrigger({

--- a/src/components/Form/Form.react.js
+++ b/src/components/Form/Form.react.js
@@ -17,7 +17,7 @@ import FormSelect from "./FormSelect.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function Form({ className, children, ...props }: Props): React.Node {

--- a/src/components/Form/FormGroup.react.js
+++ b/src/components/Form/FormGroup.react.js
@@ -7,7 +7,7 @@ import FormLabel from "./FormLabel.react";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +label?: React.Node,
+  +label?: React.Node
 |};
 
 function FormGroup({

--- a/src/components/Form/FormImageCheckItem.react.js
+++ b/src/components/Form/FormImageCheckItem.react.js
@@ -12,8 +12,8 @@ type Props = {|
     +width?: number,
     +sm?: number,
     +md?: number,
-    +lg?: number,
-  },
+    +lg?: number
+  }
 |};
 
 function FormImageCheckItem({

--- a/src/components/Form/FormInput.react.js
+++ b/src/components/Form/FormInput.react.js
@@ -12,7 +12,7 @@ type Props = {|
   +tick?: boolean,
   +invalid?: boolean,
   +cross?: boolean,
-  +feedback?: string,
+  +feedback?: string
 |};
 
 function FormInput({
@@ -32,7 +32,7 @@ function FormInput({
       "is-valid": valid,
       "state-valid": tick,
       "is-invalid": invalid,
-      "state-invalid": cross,
+      "state-invalid": cross
     },
     className
   );

--- a/src/components/Form/FormInputGroup.react.js
+++ b/src/components/Form/FormInputGroup.react.js
@@ -7,7 +7,7 @@ type Props = {|
   +children?: React.Node,
   +className?: string,
   +append?: boolean,
-  +RootComponent?: React.ElementType,
+  +RootComponent?: React.ElementType
 |};
 
 function FormInputGroup({

--- a/src/components/Grid/GridCol.react.js
+++ b/src/components/Grid/GridCol.react.js
@@ -10,7 +10,7 @@ type Props = {
   +sm?: number,
   +md?: number,
   +lg?: number,
-  +auto?: boolean,
+  +auto?: boolean
 };
 
 function GridCol({
@@ -30,7 +30,7 @@ function GridCol({
       [`col-sm-${sm}`]: sm,
       [`col-md-${md}`]: md,
       [`col-lg-${lg}`]: lg,
-      "col-auto": auto,
+      "col-auto": auto
     },
     className
   );

--- a/src/components/Grid/GridRow.react.js
+++ b/src/components/Grid/GridRow.react.js
@@ -7,7 +7,7 @@ type Props = {
   +children?: React.Node,
   +className?: string,
   +cards?: boolean,
-  +gutters?: "xs" | "sm" | "md" | "lg",
+  +gutters?: "xs" | "sm" | "md" | "lg"
 };
 
 function GridRow({
@@ -22,7 +22,7 @@ function GridRow({
     {
       row: true,
       "row-cards": cards,
-      [`gutters-${gutters}`]: gutters,
+      [`gutters-${gutters}`]: gutters
     },
     className
   );

--- a/src/components/Grid/index.js
+++ b/src/components/Grid/index.js
@@ -5,7 +5,7 @@ import GridCol from "./GridCol.react";
 
 const Grid = {
   Row: GridRow,
-  Col: GridCol,
+  Col: GridCol
 };
 
 export { Grid as default };

--- a/src/components/Header/H1.react.js
+++ b/src/components/Header/H1.react.js
@@ -6,7 +6,7 @@ import Header from "./Header.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function H1({ className, children, ...props }: Props): React.Node {

--- a/src/components/Header/H2.react.js
+++ b/src/components/Header/H2.react.js
@@ -6,7 +6,7 @@ import Header from "./Header.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function H2({ className, children, ...props }: Props): React.Node {

--- a/src/components/Header/H3.react.js
+++ b/src/components/Header/H3.react.js
@@ -6,7 +6,7 @@ import Header from "./Header.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function H3({ className, children, ...props }: Props): React.Node {

--- a/src/components/Header/H4.react.js
+++ b/src/components/Header/H4.react.js
@@ -6,7 +6,7 @@ import Header from "./Header.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function H4({ className, children, ...props }: Props): React.Node {

--- a/src/components/Header/H5.react.js
+++ b/src/components/Header/H5.react.js
@@ -6,7 +6,7 @@ import Header from "./Header.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function H5({ className, children, ...props }: Props): React.Node {

--- a/src/components/Header/Header.react.js
+++ b/src/components/Header/Header.react.js
@@ -13,7 +13,7 @@ type Props = {
   +RootComponent?: React.ElementType,
   +children?: React.Node,
   +className?: string,
-  +size: 1 | 2 | 3 | 4 | 5,
+  +size: 1 | 2 | 3 | 4 | 5
 };
 
 function Header({

--- a/src/components/Icon/Icon.react.js
+++ b/src/components/Icon/Icon.react.js
@@ -7,7 +7,7 @@ type Props = {
   +className?: string,
   +link?: boolean,
   +prefix?: "fa" | "fe",
-  +name: string,
+  +name: string
 };
 
 function Icon({
@@ -20,7 +20,7 @@ function Icon({
   const classes = cn(
     {
       [prefix]: true,
-      [`${prefix}-${name}`]: true,
+      [`${prefix}-${name}`]: true
     },
     className
   );

--- a/src/components/List/ListGroup.react.js
+++ b/src/components/List/ListGroup.react.js
@@ -6,7 +6,7 @@ import cn from "classnames";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +transparent?: boolean,
+  +transparent?: boolean
 |};
 
 function ListGroup({
@@ -19,7 +19,7 @@ function ListGroup({
     "list-group",
     "mb-0",
     {
-      "list-group-transparent": transparent,
+      "list-group-transparent": transparent
     },
     className
   );

--- a/src/components/List/ListGroupItem.react.js
+++ b/src/components/List/ListGroupItem.react.js
@@ -8,7 +8,7 @@ type Props = {|
   +className?: string,
   +RootComponent?: React.ElementType,
   +active?: boolean,
-  +icon?: string,
+  +icon?: string
 |};
 
 function ListGroupItem({
@@ -23,7 +23,7 @@ function ListGroupItem({
     "list-group-item",
     "list-group-item-action",
     {
-      active: active,
+      active: active
     },
     className
   );

--- a/src/components/List/index.js
+++ b/src/components/List/index.js
@@ -5,7 +5,7 @@ import ListGroupItem from "./ListGroupItem.react";
 
 const List = {
   Group: ListGroup,
-  GroupItem: ListGroupItem,
+  GroupItem: ListGroupItem
 };
 
 export { List as default };

--- a/src/components/Nav/Nav.react.js
+++ b/src/components/Nav/Nav.react.js
@@ -10,7 +10,7 @@ import NavSubmenuItem from "./NavSubmenuItem.react";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +tabbed?: boolean,
+  +tabbed?: boolean
 |};
 
 function Nav({

--- a/src/components/Nav/NavItem.react.js
+++ b/src/components/Nav/NavItem.react.js
@@ -5,7 +5,7 @@ import Nav from "../Nav";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +value?: string,
+  +value?: string
 |};
 
 function NavItem({ children, value, ...rest }: Props): React.Node {

--- a/src/components/Nav/NavLink.react.js
+++ b/src/components/Nav/NavLink.react.js
@@ -8,7 +8,7 @@ type Props = {
   +className?: string,
   +RootComponent?: React.ElementType,
   +active?: boolean,
-  +icon?: string,
+  +icon?: string
 };
 
 function NavLink({

--- a/src/components/Nav/NavSubmenu.react.js
+++ b/src/components/Nav/NavSubmenu.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function NavSubmenu({ className, children, ...props }: Props): React.Node {

--- a/src/components/Nav/NavSubmenuItem.react.js
+++ b/src/components/Nav/NavSubmenuItem.react.js
@@ -8,7 +8,7 @@ type Props = {|
   +className?: string,
   +RootComponent?: React.ElementType,
   +active?: boolean,
-  +icon?: string,
+  +icon?: string
 |};
 
 function NavSubmenuItem({

--- a/src/components/Page/Page.react.js
+++ b/src/components/Page/Page.react.js
@@ -10,7 +10,7 @@ import PageCard from "./PageCard.react";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function Page({ className, children, ...props }: Props): React.Node {

--- a/src/components/Page/PageCard.react.js
+++ b/src/components/Page/PageCard.react.js
@@ -9,7 +9,7 @@ type Props = {|
   +title?: string,
   +header?: React.Node,
   +footer?: React.Node,
-  +RootComponent?: React.ElementType,
+  +RootComponent?: React.ElementType
 |};
 
 function PageCard({

--- a/src/components/Page/PageContent.react.js
+++ b/src/components/Page/PageContent.react.js
@@ -6,7 +6,7 @@ import { Container } from "../";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function PageContent({ className, children, ...rest }: Props): React.Node {

--- a/src/components/Page/PageContentWithSidebar.react.js
+++ b/src/components/Page/PageContentWithSidebar.react.js
@@ -6,7 +6,7 @@ import { Page, Grid } from "../";
 type Props = {|
   +children?: React.Node,
   +header?: React.Node,
-  +sidebar?: React.Node,
+  +sidebar?: React.Node
 |};
 
 function PageContentWithSidebar({

--- a/src/components/Page/PageHeader.react.js
+++ b/src/components/Page/PageHeader.react.js
@@ -4,7 +4,7 @@ import * as React from "react";
 
 type Props = {|
   +children?: React.Node,
-  +value?: React.Node,
+  +value?: React.Node
 |};
 
 function PageHeader({ value, children, ...rest }: Props): React.Node {

--- a/src/components/Page/PageMain.react.js
+++ b/src/components/Page/PageMain.react.js
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 function PageMain({ children, ...props }: Props): React.Node {

--- a/src/components/Progress/Progress.react.js
+++ b/src/components/Progress/Progress.react.js
@@ -7,7 +7,7 @@ import ProgressBar from "./ProgressBar.react";
 type Props = {|
   +children?: React.Node,
   +className?: string,
-  +size?: string,
+  +size?: string
 |};
 
 function Progress({

--- a/src/components/Progress/ProgressBar.react.js
+++ b/src/components/Progress/ProgressBar.react.js
@@ -6,7 +6,7 @@ import cn from "classnames";
 type Props = {|
   +className?: string,
   +color?: string,
-  +width?: number,
+  +width?: number
 |};
 
 function ProgressBar({

--- a/src/components/Site/SiteHeader.react.js
+++ b/src/components/Site/SiteHeader.react.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Container } from "../";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 const SiteHeader = ({ children, ...rest }: Props): React.Node => (

--- a/src/components/Site/SiteLogo.react.js
+++ b/src/components/Site/SiteLogo.react.js
@@ -5,7 +5,7 @@ import * as React from "react";
 type Props = {|
   +href: string,
   +src: string,
-  +alt: string,
+  +alt: string
 |};
 
 const SiteLogo = (props: Props): React.Node => (

--- a/src/components/Site/SiteNavbar.react.js
+++ b/src/components/Site/SiteNavbar.react.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Container, Header } from "../";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 const SiteNav = (props: Props): React.Node => (

--- a/src/components/Table/Table.react.js
+++ b/src/components/Table/Table.react.js
@@ -13,7 +13,7 @@ type Props = {|
   +className?: string,
   +cards?: boolean,
   +striped?: boolean,
-  +responsive?: boolean,
+  +responsive?: boolean
 |};
 
 function Table({
@@ -45,7 +45,7 @@ function Table({
 Table.defaultProps = {
   cards: false,
   striped: false,
-  responsive: false,
+  responsive: false
 };
 
 Table.Header = TableHeader;

--- a/src/components/Table/TableColHeader.react.js
+++ b/src/components/Table/TableColHeader.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function TableColHeader({ className, children, ...props }: Props): React.Node {

--- a/src/components/Table/TableHeader.react.js
+++ b/src/components/Table/TableHeader.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function TableHeader({ className, children, ...props }: Props): React.Node {

--- a/src/components/Table/TableRow.react.js
+++ b/src/components/Table/TableRow.react.js
@@ -5,7 +5,7 @@ import cn from "classnames";
 
 type Props = {|
   +children?: React.Node,
-  +className?: string,
+  +className?: string
 |};
 
 function TableRow({ className, children, ...props }: Props): React.Node {

--- a/src/components/Text/Text.react.js
+++ b/src/components/Text/Text.react.js
@@ -9,7 +9,7 @@ type Props = {|
   +RootComponent?: React.ElementType,
   +color: string,
   +size: string,
-  +wrap?: boolean,
+  +wrap?: boolean
 |};
 
 const Text = ({
@@ -25,7 +25,7 @@ const Text = ({
     {
       [`text-wrap p-lg-6`]: wrap,
       [`text-${color}`]: color,
-      [`${size}`]: size,
+      [`${size}`]: size
     },
     className
   );

--- a/src/forms/Form.react.js
+++ b/src/forms/Form.react.js
@@ -6,7 +6,8 @@ type Props = {|
   +action: string,
   +children?: React.Node,
   +method: string,
-  +title: string
+  +title: string,
+  +buttonText: string
 |};
 
 function Form(props: Props): React.Node {
@@ -17,7 +18,7 @@ function Form(props: Props): React.Node {
         {props.children}
         <div className="form-footer">
           <button type="submit" className="btn btn-primary btn-block">
-            Create new account
+            {props.buttonText}
           </button>
         </div>
       </div>

--- a/src/forms/FormCheckboxInput.react.js
+++ b/src/forms/FormCheckboxInput.react.js
@@ -1,0 +1,43 @@
+// @flow
+
+import * as React from "react";
+
+type Props = {|
+  +label: string
+|};
+
+type State = {
+  value: boolean
+};
+
+class FormCheckboxInput extends React.PureComponent<Props, State> {
+  state = {
+    value: false
+  };
+
+  _handleChange = (event: SyntheticInputEvent<HTMLInputElement>): void => {
+    this.setState((prevState, _) => ({
+      value: !prevState.value
+    }));
+  };
+
+  render(): React.Node {
+    const { label } = this.props;
+    const { value } = this.state;
+    return (
+      <div className="form-group">
+        <label className="custom-control custom-checkbox">
+          <input
+            type="checkbox"
+            className="custom-control-input"
+            onChange={this._handleChange}
+            checked={value}
+          />
+          <span className="custom-control-label">{label}</span>
+        </label>
+      </div>
+    );
+  }
+}
+
+export default FormCheckboxInput;

--- a/src/index.js
+++ b/src/index.js
@@ -6,3 +6,4 @@ export {
 } from "./page_templates/StandaloneFormPage.react";
 export { default as Form } from "./forms/Form.react";
 export { default as FormTextInput } from "./forms/FormTextInput.react";
+export { default as FormCheckboxInput } from "./forms/FormCheckboxInput.react";

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 // @flow
 
 export * from "./components";
-export {default as StandaloneFormPage} from './page_templates/StandaloneFormPage.react';
-export {default as Form} from './forms/Form.react';
-export {default as FormTextInput} from './forms/FormTextInput.react';
+export {
+  default as StandaloneFormPage
+} from "./page_templates/StandaloneFormPage.react";
+export { default as Form } from "./forms/Form.react";
+export { default as FormTextInput } from "./forms/FormTextInput.react";

--- a/src/page_templates/StandaloneFormPage.react.js
+++ b/src/page_templates/StandaloneFormPage.react.js
@@ -1,9 +1,9 @@
 // @flow
 
-import * as React from 'react';
+import * as React from "react";
 
 type Props = {|
-  +children?: React.Node,
+  +children?: React.Node
 |};
 
 function StandaloneFormPage(props: Props): React.Node {

--- a/src/page_templates/StandaloneFormPage.react.js
+++ b/src/page_templates/StandaloneFormPage.react.js
@@ -8,14 +8,16 @@ type Props = {|
 
 function StandaloneFormPage(props: Props): React.Node {
   return (
-    <div className="page-single">
-      <div className="container">
-        <div className="row">
-          <div className="col col-login mx-auto">
-            <div className="text-center mb-6">
-              <img src="./assets/brand/tabler.svg" className="h-6" alt="" />
+    <div className="page">
+      <div className="page-single">
+        <div className="container">
+          <div className="row">
+            <div className="col col-login mx-auto">
+              <div className="text-center mb-6">
+                <img src="./assets/brand/tabler.svg" className="h-6" alt="" />
+              </div>
+              {props.children}
             </div>
-            {props.children}
           </div>
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,7 +1629,7 @@ chokidar@^1.6.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.2:
+chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
   dependencies:
@@ -1715,6 +1715,14 @@ cliui@^3.2.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
+
+cliui@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
 clone@^1.0.2:
@@ -3123,6 +3131,16 @@ flow-bin@^0.69.0:
   version "0.69.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
 
+flow-copy-source@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-1.3.0.tgz#591b153f5c01e8fc566c64a97290ea9103b7f1ea"
+  dependencies:
+    chokidar "^2.0.0"
+    fs-extra "^5.0.0"
+    glob "^7.0.0"
+    kefir "^3.7.3"
+    yargs "^11.0.0"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3314,7 +3332,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4563,6 +4581,12 @@ jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:
     array-includes "^3.0.3"
+
+kefir@^3.7.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.3.tgz#8e0ab10084ed8a01cbb5d4f7f18a0b859f7b9bd9"
+  dependencies:
+    symbol-observable "1.0.4"
 
 killable@^1.0.0:
   version "1.0.0"
@@ -7075,6 +7099,10 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
+symbol-observable@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -7748,6 +7776,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^6.6.0:
   version "6.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,6 +1677,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"


### PR DESCRIPTION
We were not including **classnames** in the package.json file somehow, this was leading to a build issue for me.  Fixed this, use Router in example for rendering pages based on URL, added export of flow types so now if you add illegal props or are missing required props in the example, flow will yell at you.  Previously, the flow types defined in `src/` were showing as `any` when being used in example, this export piece fixes that.  Also added register and login pages (screenshots attached).

@jonthomp Linter modified a ton of files - sorry as I'm sure that makes it hard to review.  Let's definitely make sure we are using the exact same prettier config so this won't make things difficult again :)
![login-page](https://user-images.githubusercontent.com/9311453/38836464-3694960e-419c-11e8-826d-1ee8f392634b.PNG)
![register-page](https://user-images.githubusercontent.com/9311453/38836465-36a9eefa-419c-11e8-97ea-29e28c49209b.PNG)

