### PR TITLE
Refactor form input components to use basic components.

### DIFF
--- a/src/components/Form/FormInput.react.js
+++ b/src/components/Form/FormInput.react.js
@@ -42,6 +42,7 @@ function FormInput(props: Props): React.Node {
   const classes = cn(
     "form-control",
     {
+      "custom-control-input": type === "checkbox",
       "is-valid": valid,
       "state-valid": tick,
       "is-invalid": invalid,
@@ -57,6 +58,7 @@ function FormInput(props: Props): React.Node {
           type={type}
           placeholder={placeholder}
           checked={value}
+          value={value}
           onChange={onChange}
         />
       ) : (

--- a/src/components/Form/FormInput.react.js
+++ b/src/components/Form/FormInput.react.js
@@ -4,7 +4,7 @@ import * as React from "react";
 import { Icon } from "../";
 import cn from "classnames";
 
-type Props = {|
+type FormStyle = {|
   +className?: string,
   +icon?: string,
   +position?: "append" | "prepend",
@@ -15,16 +15,30 @@ type Props = {|
   +feedback?: string,
 |};
 
-function FormInput({
-  className,
-  icon,
-  position = "prepend",
-  valid,
-  tick,
-  invalid,
-  cross,
-  feedback,
-}: Props): React.Node {
+type Props = {|
+  ...FormStyle,
+  +onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
+  +placeholder?: string,
+  +type?: "checkbox" | "text" | "email" | "password",
+  +value?: string | number | boolean,
+|};
+
+function FormInput(props: Props): React.Node {
+  const {
+    className,
+    icon,
+    position = "prepend",
+    valid,
+    tick,
+    invalid,
+    cross,
+    feedback,
+    placeholder,
+    value,
+    onChange,
+  } = props;
+  const type = props.type || "text";
+
   const classes = cn(
     "form-control",
     {
@@ -37,7 +51,23 @@ function FormInput({
   );
   return !icon ? (
     <React.Fragment>
-      <input className={classes} />
+      {type === "checkbox" ? (
+        <input
+          className={classes}
+          type={type}
+          placeholder={placeholder}
+          checked={value}
+          onChange={onChange}
+        />
+      ) : (
+        <input
+          className={classes}
+          type={type}
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+        />
+      )}
       {feedback &&
         (invalid || cross) && (
           <span className="invalid-feedback">{feedback}</span>

--- a/src/forms/FormCheckboxInput.react.js
+++ b/src/forms/FormCheckboxInput.react.js
@@ -31,7 +31,6 @@ class FormCheckboxInput extends React.PureComponent<Props, State> {
         <label className="custom-control custom-checkbox">
           <Form.Input
             type="checkbox"
-            className="custom-control-input"
             onChange={this._handleChange}
             value={value}
           />

--- a/src/forms/FormCheckboxInput.react.js
+++ b/src/forms/FormCheckboxInput.react.js
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 
+import Form from "../components/Form";
+
 type Props = {|
   +label: string,
 |};
@@ -25,17 +27,17 @@ class FormCheckboxInput extends React.PureComponent<Props, State> {
     const { label } = this.props;
     const { value } = this.state;
     return (
-      <div className="form-group">
+      <Form.Group>
         <label className="custom-control custom-checkbox">
-          <input
+          <Form.Input
             type="checkbox"
             className="custom-control-input"
             onChange={this._handleChange}
-            checked={value}
+            value={value}
           />
           <span className="custom-control-label">{label}</span>
         </label>
-      </div>
+      </Form.Group>
     );
   }
 }

--- a/src/forms/FormTextInput.react.js
+++ b/src/forms/FormTextInput.react.js
@@ -2,14 +2,16 @@
 
 import * as React from "react";
 
+import Form from "../components/Form";
+
 type Props = {|
-  +type?: string,
+  +type?: "checkbox" | "text" | "email" | "password",
   +label: string,
   +placeHolder: string,
 |};
 
 type State = {|
-  value: string,
+  value: string | number,
 |};
 
 class FormTextInput extends React.PureComponent<Props, State> {
@@ -26,18 +28,28 @@ class FormTextInput extends React.PureComponent<Props, State> {
     const { label, placeHolder } = this.props;
     const { value } = this.state;
     return (
-      <div className="form-group">
-        <label className="form-label">{label}</label>
-        <input
-          className="form-control"
+      <Form.Group label={label}>
+        <Form.Input
           onChange={this._handleChange}
           placeholder={placeHolder}
           type={type}
           value={value}
         />
-      </div>
+      </Form.Group>
     );
   }
 }
+
+/*
+
+<input
+  className="form-control"
+  onChange={this._handleChange}
+  placeholder={placeHolder}
+  type={type}
+  value={value}
+/>
+
+*/
 
 export default FormTextInput;


### PR DESCRIPTION
The `FormInput` component alone is kind of abstract and hard to use - it also has a ton of properties.  Thus, I've added two out of the box solutions for this - one is `FormCheckboxInput` (self explanatory), the other is `FormTextInput`, used for email, password, text, number, etc (anything that can be represented by text).  These are useful out of the box form inputs that track state and people can use instead of the base `FormInput` component.