### PR TITLE
Sets displayName to match actual component usage

### DIFF
--- a/src/components/Alert/AlertLink.react.js
+++ b/src/components/Alert/AlertLink.react.js
@@ -18,4 +18,6 @@ function AlertLink({ children, className, href }: Props): React.Node {
   );
 }
 
+AlertLink.displayName = "Alert.Link";
+
 export default AlertLink;

--- a/src/components/Avatar/AvatarList.react.js
+++ b/src/components/Avatar/AvatarList.react.js
@@ -20,4 +20,6 @@ function AvatarList({ className, children, stacked }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+AvatarList.displayName = "Avatar.List";
+
 export default AvatarList;

--- a/src/components/Button/ButtonList.react.js
+++ b/src/components/Button/ButtonList.react.js
@@ -26,4 +26,6 @@ function ButtonList({
   );
 }
 
+ButtonList.displayName = "Button.List";
+
 export default ButtonList;

--- a/src/components/Card/CardBody.react.js
+++ b/src/components/Card/CardBody.react.js
@@ -13,4 +13,6 @@ function CardBody({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+CardBody.displayName = "Card.Body";
+
 export default CardBody;

--- a/src/components/Card/CardHeader.react.js
+++ b/src/components/Card/CardHeader.react.js
@@ -13,4 +13,6 @@ function CardHeader({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+CardHeader.displayName = "Card.Header";
+
 export default CardHeader;

--- a/src/components/Card/CardTitle.react.js
+++ b/src/components/Card/CardTitle.react.js
@@ -15,4 +15,6 @@ function CardTitle({ className, children, RootComponent }: Props): React.Node {
   return <Component className={classes}>{children}</Component>;
 }
 
+CardTitle.displayName = "Card.Title";
+
 export default CardTitle;

--- a/src/components/Dropdown/DropdownItem.react.js
+++ b/src/components/Dropdown/DropdownItem.react.js
@@ -51,4 +51,6 @@ function DropdownItem({
   );
 }
 
+DropdownItem.displayName = "Dropdown.Item";
+
 export default DropdownItem;

--- a/src/components/Dropdown/DropdownItemDivider.react.js
+++ b/src/components/Dropdown/DropdownItemDivider.react.js
@@ -10,4 +10,6 @@ function DropdownItemDivider(props: Props): React.Node {
   return <div className="dropdown-divider">{props.children}</div>;
 }
 
+DropdownItemDivider.displayName = "Dropdown.ItemDivider";
+
 export default DropdownItemDivider;

--- a/src/components/Dropdown/DropdownMenu.react.js
+++ b/src/components/Dropdown/DropdownMenu.react.js
@@ -27,4 +27,6 @@ function DropdownMenu({
   return <div className={classes}>{children}</div>;
 }
 
+DropdownMenu.displayName = "Dropdown.Menu";
+
 export default DropdownMenu;

--- a/src/components/Dropdown/DropdownTrigger.react.js
+++ b/src/components/Dropdown/DropdownTrigger.react.js
@@ -46,4 +46,6 @@ function DropdownTrigger({
   );
 }
 
+DropdownTrigger.displayName = "Dropdown.Trigger";
+
 export default DropdownTrigger;

--- a/src/components/Form/FormColorCheck.react.js
+++ b/src/components/Form/FormColorCheck.react.js
@@ -11,4 +11,6 @@ function FormColorCheck({ className, children }: Props): React.Node {
   return <Grid.Row className={classes}>{children}</Grid.Row>;
 }
 
+FormColorCheck.displayName = "Form.ColorCheck";
+
 export default FormColorCheck;

--- a/src/components/Form/FormColorCheckItem.react.js
+++ b/src/components/Form/FormColorCheckItem.react.js
@@ -23,4 +23,6 @@ function FormColorCheckItem({ className, color }: Props): React.Node {
   );
 }
 
+FormColorCheckItem.displayName = "Form.ColorCheckItem";
+
 export default FormColorCheckItem;

--- a/src/components/Form/FormFooter.react.js
+++ b/src/components/Form/FormFooter.react.js
@@ -13,4 +13,6 @@ function FormFooter(props: Props): React.Node {
   return <div className={classes}>{props.children}</div>;
 }
 
+FormFooter.displayName = "Form.Footer";
+
 export default FormFooter;

--- a/src/components/Form/FormGroup.react.js
+++ b/src/components/Form/FormGroup.react.js
@@ -24,4 +24,6 @@ function FormGroup({ className, children, label }: Props): React.Node {
   );
 }
 
+FormGroup.displayName = "Form.Group";
+
 export default FormGroup;

--- a/src/components/Form/FormHelp.react.js
+++ b/src/components/Form/FormHelp.react.js
@@ -29,4 +29,6 @@ function FormHelp({
   );
 }
 
+FormHelp.displayName = "Form.Help";
+
 export default FormHelp;

--- a/src/components/Form/FormImageCheck.react.js
+++ b/src/components/Form/FormImageCheck.react.js
@@ -11,4 +11,6 @@ function FormImageCheck({ className, children }: Props): React.Node {
   return <Grid.Row className={classes}>{children}</Grid.Row>;
 }
 
+FormImageCheck.displayName = "Form.ImageCheck";
+
 export default FormImageCheck;

--- a/src/components/Form/FormImageCheckItem.react.js
+++ b/src/components/Form/FormImageCheckItem.react.js
@@ -38,4 +38,6 @@ function FormImageCheckItem({
   );
 }
 
+FormImageCheckItem.displayName = "Form.ImageCheckItem";
+
 export default FormImageCheckItem;

--- a/src/components/Form/FormInput.react.js
+++ b/src/components/Form/FormInput.react.js
@@ -104,4 +104,6 @@ function FormInput(props: Props): React.Node {
   );
 }
 
+FormInput.displayName = "Form.Input";
+
 export default FormInput;

--- a/src/components/Form/FormInputGroup.react.js
+++ b/src/components/Form/FormInputGroup.react.js
@@ -24,4 +24,6 @@ function FormInputGroup({
   return <Component className={classes}>{children}</Component>;
 }
 
+FormInputGroup.displayName = "Form.InputGroup";
+
 export default FormInputGroup;

--- a/src/components/Form/FormLabel.react.js
+++ b/src/components/Form/FormLabel.react.js
@@ -15,4 +15,6 @@ function FormLabel({ className, aside, children }: Props): React.Node {
   );
 }
 
+FormLabel.displayName = "Form.Label";
+
 export default FormLabel;

--- a/src/components/Form/FormSelect.react.js
+++ b/src/components/Form/FormSelect.react.js
@@ -13,4 +13,6 @@ function FormSelect({ className, children }: Props): React.Node {
   return <select className={classes}>{children}</select>;
 }
 
+FormSelect.displayName = "Form.Select";
+
 export default FormSelect;

--- a/src/components/Form/FormStaticText.react.js
+++ b/src/components/Form/FormStaticText.react.js
@@ -10,4 +10,6 @@ function FormStaticText({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+FormStaticText.displayName = "Form.StaticText";
+
 export default FormStaticText;

--- a/src/components/Form/FormTextarea.react.js
+++ b/src/components/Form/FormTextarea.react.js
@@ -36,4 +36,6 @@ function FormTextarea({
   );
 }
 
+FormTextarea.displayName = "Form.Textarea";
+
 export default FormTextarea;

--- a/src/components/Grid/GridCol.react.js
+++ b/src/components/Grid/GridCol.react.js
@@ -45,4 +45,6 @@ function GridCol({
   return <div className={classes}>{children}</div>;
 }
 
+GridCol.displayName = "Grid.Col";
+
 export default GridCol;

--- a/src/components/Grid/GridRow.react.js
+++ b/src/components/Grid/GridRow.react.js
@@ -28,4 +28,6 @@ function GridRow({
   return <div className={classes}>{children}</div>;
 }
 
+GridRow.displayName = "Grid.Row";
+
 export default GridRow;

--- a/src/components/Header/H1.react.js
+++ b/src/components/Header/H1.react.js
@@ -18,4 +18,6 @@ function H1({ className, children }: Props): React.Node {
   );
 }
 
+H1.displayName = "Header.H1";
+
 export default H1;

--- a/src/components/Header/H2.react.js
+++ b/src/components/Header/H2.react.js
@@ -18,4 +18,6 @@ function H2({ className, children }: Props): React.Node {
   );
 }
 
+H2.displayName = "Header.H2";
+
 export default H2;

--- a/src/components/Header/H3.react.js
+++ b/src/components/Header/H3.react.js
@@ -18,4 +18,6 @@ function H3({ className, children }: Props): React.Node {
   );
 }
 
+H3.displayName = "Header.H3";
+
 export default H3;

--- a/src/components/Header/H4.react.js
+++ b/src/components/Header/H4.react.js
@@ -18,4 +18,6 @@ function H4({ className, children }: Props): React.Node {
   );
 }
 
+H4.displayName = "Header.H4";
+
 export default H4;

--- a/src/components/Header/H5.react.js
+++ b/src/components/Header/H5.react.js
@@ -18,4 +18,6 @@ function H5({ className, children }: Props): React.Node {
   );
 }
 
+H5.displayName = "Header.H5";
+
 export default H5;

--- a/src/components/List/ListGroup.react.js
+++ b/src/components/List/ListGroup.react.js
@@ -21,4 +21,6 @@ function ListGroup({ className, children, transparent }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+ListGroup.displayName = "List.Group";
+
 export default ListGroup;

--- a/src/components/List/ListGroupItem.react.js
+++ b/src/components/List/ListGroupItem.react.js
@@ -52,4 +52,6 @@ function ListGroupItem({
   );
 }
 
+ListGroupItem.displayName = "List.GroupItem";
+
 export default ListGroupItem;

--- a/src/components/List/ListItem.react.js
+++ b/src/components/List/ListItem.react.js
@@ -13,4 +13,6 @@ function ListItem({ className, children }: Props): React.Node {
   return <li className={classes}>{children}</li>;
 }
 
+ListItem.displayName = "List.Item";
+
 export default ListItem;

--- a/src/components/Nav/NavItem.react.js
+++ b/src/components/Nav/NavItem.react.js
@@ -47,4 +47,6 @@ function NavItem({
   );
 }
 
+NavItem.displayName = "Nav.Item";
+
 export default NavItem;

--- a/src/components/Nav/NavLink.react.js
+++ b/src/components/Nav/NavLink.react.js
@@ -50,4 +50,6 @@ function NavLink({
   );
 }
 
+NavLink.displayName = "Nav.Link";
+
 export default NavLink;

--- a/src/components/Nav/NavSubItem.react.js
+++ b/src/components/Nav/NavSubItem.react.js
@@ -27,4 +27,6 @@ function NavSubItem({
   );
 }
 
+NavSubItem.displayName = "Nav.SubItem";
+
 export default NavSubItem;

--- a/src/components/Nav/NavSubmenu.react.js
+++ b/src/components/Nav/NavSubmenu.react.js
@@ -13,4 +13,6 @@ function NavSubmenu({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+NavSubmenu.displayName = "Nav.Submenu";
+
 export default NavSubmenu;

--- a/src/components/Nav/NavSubmenuItem.react.js
+++ b/src/components/Nav/NavSubmenuItem.react.js
@@ -34,4 +34,6 @@ function NavSubmenuItem({
   );
 }
 
+NavSubmenuItem.displayName = "Nav.SubmenuItem";
+
 export default NavSubmenuItem;

--- a/src/components/Page/PageCard.react.js
+++ b/src/components/Page/PageCard.react.js
@@ -41,4 +41,6 @@ function PageCard({
   );
 }
 
+PageCard.displayName = "Page.Card";
+
 export default PageCard;

--- a/src/components/Page/PageContent.react.js
+++ b/src/components/Page/PageContent.react.js
@@ -18,4 +18,6 @@ function PageContent({ className, children }: Props): React.Node {
   );
 }
 
+PageContent.displayName = "Page.Content";
+
 export default PageContent;

--- a/src/components/Page/PageContentWithSidebar.react.js
+++ b/src/components/Page/PageContentWithSidebar.react.js
@@ -27,4 +27,6 @@ function PageContentWithSidebar({
   );
 }
 
+PageContentWithSidebar.displayName = "Page.ContentWithSidebar";
+
 export default PageContentWithSidebar;

--- a/src/components/Page/PageHeader.react.js
+++ b/src/components/Page/PageHeader.react.js
@@ -15,4 +15,6 @@ function PageHeader({ children }: Props): React.Node {
   );
 }
 
+PageHeader.displayName = "Page.Header";
+
 export default PageHeader;

--- a/src/components/Page/PageMain.react.js
+++ b/src/components/Page/PageMain.react.js
@@ -10,4 +10,6 @@ function PageMain({ children }: Props): React.Node {
   return <div className={"page-main"}>{children}</div>;
 }
 
+PageMain.displayName = "Page.Main";
+
 export default PageMain;

--- a/src/components/Page/PageTitle.react.js
+++ b/src/components/Page/PageTitle.react.js
@@ -13,4 +13,6 @@ function PageTitle({ className, children }: Props): React.Node {
   return <h1 className={classes}>{children}</h1>;
 }
 
+PageTitle.displayName = "Page.Title";
+
 export default PageTitle;

--- a/src/components/PricingCard/PricingCardAttributeItem.react.js
+++ b/src/components/PricingCard/PricingCardAttributeItem.react.js
@@ -36,4 +36,6 @@ function PricingCardAttributeItem({
   );
 }
 
+PricingCardAttributeItem.displayName = "PricingCard.AttributeItem";
+
 export default PricingCardAttributeItem;

--- a/src/components/PricingCard/PricingCardAttributeList.react.js
+++ b/src/components/PricingCard/PricingCardAttributeList.react.js
@@ -13,4 +13,6 @@ function PricingCardAttributeList({ className, children }: Props): React.Node {
   return <ul className={classes}>{children}</ul>;
 }
 
+PricingCardAttributeList.displayName = "PricingCard.AttributeList";
+
 export default PricingCardAttributeList;

--- a/src/components/PricingCard/PricingCardButton.react.js
+++ b/src/components/PricingCard/PricingCardButton.react.js
@@ -33,4 +33,6 @@ function PricingCardButton({
   );
 }
 
+PricingCardButton.displayName = "PricingCard.Button";
+
 export default PricingCardButton;

--- a/src/components/PricingCard/PricingCardCategory.react.js
+++ b/src/components/PricingCard/PricingCardCategory.react.js
@@ -13,4 +13,6 @@ function PricingCardCategory({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+PricingCardCategory.displayName = "PricingCard.Category";
+
 export default PricingCardCategory;

--- a/src/components/PricingCard/PricingCardPrice.react.js
+++ b/src/components/PricingCard/PricingCardPrice.react.js
@@ -13,4 +13,6 @@ function PricingCardPrice({ className, children }: Props): React.Node {
   return <div className={classes}>{children}</div>;
 }
 
+PricingCardPrice.displayName = "PricingCard.Price";
+
 export default PricingCardPrice;

--- a/src/components/Progress/ProgressBar.react.js
+++ b/src/components/Progress/ProgressBar.react.js
@@ -14,4 +14,6 @@ function ProgressBar({ className, color = "", width = 0 }: Props): React.Node {
   return <div className={classes} style={{ width: `${width}%` }} />;
 }
 
+ProgressBar.displayName = "Progress.Bar";
+
 export default ProgressBar;

--- a/src/components/Site/SiteFooter.react.js
+++ b/src/components/Site/SiteFooter.react.js
@@ -106,4 +106,6 @@ const SiteFooter = () => (
   </React.Fragment>
 );
 
+SiteFooter.displayName = "Site.Footer";
+
 export default SiteFooter;

--- a/src/components/Site/SiteHeader.react.js
+++ b/src/components/Site/SiteHeader.react.js
@@ -15,4 +15,6 @@ const SiteHeader = ({ children }: Props): React.Node => (
   </div>
 );
 
+SiteHeader.displayName = "Site.Header";
+
 export default SiteHeader;

--- a/src/components/Site/SiteLogo.react.js
+++ b/src/components/Site/SiteLogo.react.js
@@ -14,4 +14,6 @@ const SiteLogo = (props: Props): React.Node => (
   </a>
 );
 
+SiteLogo.displayName = "Site.Logo";
+
 export default SiteLogo;

--- a/src/components/Site/SiteNavbar.react.js
+++ b/src/components/Site/SiteNavbar.react.js
@@ -12,4 +12,7 @@ const SiteNav = (props: Props): React.Node => (
     <Container>{props.children}</Container>
   </div>
 );
+
+SiteNav.displayName = "Site.Nav";
+
 export default SiteNav;

--- a/src/components/Table/TableBody.react.js
+++ b/src/components/Table/TableBody.react.js
@@ -13,4 +13,6 @@ function TableBody({ className, children, ...props }: Props): React.Node {
   );
 }
 
+TableBody.displayName = "Table.Body";
+
 export default TableBody;

--- a/src/components/Table/TableCol.react.js
+++ b/src/components/Table/TableCol.react.js
@@ -14,4 +14,6 @@ function TableCol({ className, children, ...props }: Props): React.Node {
   );
 }
 
+TableCol.displayName = "Table.Col";
+
 export default TableCol;

--- a/src/components/Table/TableColHeader.react.js
+++ b/src/components/Table/TableColHeader.react.js
@@ -18,4 +18,6 @@ function TableColHeader({ className, children, colSpan }: Props): React.Node {
   );
 }
 
+TableColHeader.displayName = "Table.ColHeader";
+
 export default TableColHeader;

--- a/src/components/Table/TableHeader.react.js
+++ b/src/components/Table/TableHeader.react.js
@@ -17,4 +17,6 @@ function TableHeader({ className, children, ...props }: Props): React.Node {
   );
 }
 
+TableHeader.displayName = "Table.Header";
+
 export default TableHeader;

--- a/src/components/Table/TableRow.react.js
+++ b/src/components/Table/TableRow.react.js
@@ -17,4 +17,6 @@ function TableRow({ className, children, ...props }: Props): React.Node {
   );
 }
 
+TableRow.displayName = "Table.Row";
+
 export default TableRow;


### PR DESCRIPTION
This updates the dispayName for components that use a dot notation so that they are displayed within devtools and the demo component using the name you actually use when building with the component

![screenshot from 2018-04-23 23-30-34](https://user-images.githubusercontent.com/660222/39156590-c9fcf550-474e-11e8-8107-069f999e204b.png)
