### PR TITLE
Table shorthand props

### DIFF
--- a/example/src/HomePage.react.js
+++ b/example/src/HomePage.react.js
@@ -241,8 +241,8 @@ function Home() {
           <Grid.Col md={6}>
             <Alert type="primary">
               Are you in trouble?{" "}
-              <Alert.Link href="/docs">Read our documentation</Alert.Link>{" "}
-              with code samples.
+              <Alert.Link href="/docs">Read our documentation</Alert.Link> with
+              code samples.
             </Alert>
             <Grid.Row>
               <Grid.Col sm={6}>
@@ -834,20 +834,18 @@ function Home() {
               <Table
                 responsive
                 className="card-table table-vcenter text-nowrap"
+                headerItems={[
+                  { content: "No.", className: "w-1" },
+                  { content: "Invoice Subject" },
+                  { content: "Client" },
+                  { content: "VAT No." },
+                  { content: "Created" },
+                  { content: "Status" },
+                  { content: "Price" },
+                  { content: null },
+                  { content: null },
+                ]}
               >
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColHeader className="w-1">No.</Table.ColHeader>
-                    <Table.ColHeader>Invoice Subject</Table.ColHeader>
-                    <Table.ColHeader>Client</Table.ColHeader>
-                    <Table.ColHeader>VAT No.</Table.ColHeader>
-                    <Table.ColHeader>Created</Table.ColHeader>
-                    <Table.ColHeader>Status</Table.ColHeader>
-                    <Table.ColHeader>Price</Table.ColHeader>
-                    <Table.ColHeader />
-                    <Table.ColHeader />
-                  </Table.Row>
-                </Table.Header>
                 <Table.Body>
                   <Table.Row>
                     <Table.Col>

--- a/example/src/HomePage.react.js
+++ b/example/src/HomePage.react.js
@@ -845,42 +845,56 @@ function Home() {
                   { content: null },
                   { content: null },
                 ]}
-              >
-                <Table.Body>
-                  <Table.Row>
-                    <Table.Col>
-                      <Text RootComponent="span" muted>
-                        001401
-                      </Text>
-                    </Table.Col>
-                    <Table.Col>
-                      <a href="invoice.html" className="text-inherit">
-                        Design Works
-                      </a>
-                    </Table.Col>
-                    <Table.Col>Carlson Limited</Table.Col>
-                    <Table.Col>87956621</Table.Col>
-                    <Table.Col>15 Dec 2017</Table.Col>
-                    <Table.Col>
-                      <span className="status-icon bg-success" /> Paid
-                    </Table.Col>
-                    <Table.Col>$887</Table.Col>
-                    <Table.Col alignContent="right">
-                      <Button size="sm" color="secondary">
-                        Manage
-                      </Button>
-                      <div className="dropdown">
-                        <Button color="secondary" size="sm" isDropdownToggle>
-                          Actions
-                        </Button>
-                      </div>
-                    </Table.Col>
-                    <Table.Col>
-                      <Icon link name="edit" />
-                    </Table.Col>
-                  </Table.Row>
-                </Table.Body>
-              </Table>
+                bodyItems={[
+                  [
+                    {
+                      content: (
+                        <Text RootComponent="span" muted>
+                          001401
+                        </Text>
+                      ),
+                    },
+                    {
+                      content: (
+                        <a href="invoice.html" className="text-inherit">
+                          Design Works
+                        </a>
+                      ),
+                    },
+                    { content: "Carlson Limited" },
+                    { content: "87956621" },
+                    { content: "15 Dec 2017" },
+                    {
+                      content: (
+                        <React.Fragment>
+                          <span className="status-icon bg-success" /> Paid
+                        </React.Fragment>
+                      ),
+                    },
+                    { content: "$887" },
+                    {
+                      alignContent: "right",
+                      content: (
+                        <React.Fragment>
+                          <Button size="sm" color="secondary">
+                            Manage
+                          </Button>
+                          <div className="dropdown">
+                            <Button
+                              color="secondary"
+                              size="sm"
+                              isDropdownToggle
+                            >
+                              Actions
+                            </Button>
+                          </div>
+                        </React.Fragment>
+                      ),
+                    },
+                    { content: <Icon link name="edit" /> },
+                  ],
+                ]}
+              />
             </Card>
           </Grid.Col>
         </Grid.Row>

--- a/src/components/Table/Table.react.js
+++ b/src/components/Table/Table.react.js
@@ -17,6 +17,7 @@ type Props = {|
   +highlightRowOnHover?: boolean,
   +hasOutline?: boolean,
   +verticalAlign?: "center",
+  +headerItems?: Array<{ +content?: React.Node, className: string }>,
 |};
 
 function Table({
@@ -41,17 +42,27 @@ function Table({
     },
     className
   );
-  return !responsive ? (
+
+  const header = props.headerItems && (
+    <Table.Header>
+      <Table.Row>
+        {props.headerItems.map((item, i) => (
+          <Table.ColHeader key={i} className={item.className}>
+            {item.content}
+          </Table.ColHeader>
+        ))}
+      </Table.Row>
+    </Table.Header>
+  );
+
+  const table = (
     <table className={classes} {...props}>
+      {header}
       {children}
     </table>
-  ) : (
-    <div className="table-responsive">
-      <table className={classes} {...props}>
-        {children}
-      </table>
-    </div>
   );
+
+  return !responsive ? table : <div className="table-responsive">{table}</div>;
 }
 
 Table.defaultProps = {

--- a/src/components/Table/Table.react.js
+++ b/src/components/Table/Table.react.js
@@ -17,7 +17,14 @@ type Props = {|
   +highlightRowOnHover?: boolean,
   +hasOutline?: boolean,
   +verticalAlign?: "center",
-  +headerItems?: Array<{ +content?: React.Node, className: string }>,
+  +headerItems?: Array<{ +content?: React.Node, +className?: string }>,
+  +bodyItems?: Array<
+    Array<{
+      +content?: React.Node,
+      +className?: string,
+      +alignContent?: "left" | "center" | "right",
+    }>
+  >,
 |};
 
 function Table({
@@ -55,10 +62,27 @@ function Table({
     </Table.Header>
   );
 
+  const body = props.bodyItems && (
+    <Table.Body>
+      {props.bodyItems.map((row, i) => (
+        <Table.Row>
+          {row.map(col => (
+            <Table.Col
+              className={col.className}
+              alignContent={col.alignContent}
+            >
+              {col.content}
+            </Table.Col>
+          ))}
+        </Table.Row>
+      ))}
+    </Table.Body>
+  );
+
   const table = (
     <table className={classes} {...props}>
       {header}
-      {children}
+      {body || children}
     </table>
   );
 


### PR DESCRIPTION
Adds Tabler headerItems and bodyItems shorthand props

Example:
```jsx
<Table
  headerItems={[
    { content: "Name", className: "w-1" },
    { content: "Action" },
  ]}
  bodyItems={[
    [
      {
        content: 'Jon',
      },
      {
	    alignContent: 'right',
		content: <Button>Action</Button>
	  }
	]
 ]}
/>
```