### PR TITLE
Page header shorthand props

### DIFF
--- a/example/src/GalleryPage.react.js
+++ b/example/src/GalleryPage.react.js
@@ -13,9 +13,7 @@ import json from "./data/Gallery.Items";
 function GalleryPage(): React.Node {
   return (
     <SiteWrapper>
-      <Page.Content>
-        <Page.Header title="Gallery" />
-
+      <Page.Content title="Gallery">
         <Grid.Row className="row-cards">
           {json.items.map(item => (
             <Grid.Col sm={6} lg={4}>

--- a/example/src/GalleryPage.react.js
+++ b/example/src/GalleryPage.react.js
@@ -14,7 +14,7 @@ function GalleryPage(): React.Node {
   return (
     <SiteWrapper>
       <Page.Content>
-        <Page.Header>Gallery</Page.Header>
+        <Page.Header title="Gallery" />
 
         <Grid.Row className="row-cards">
           {json.items.map(item => (

--- a/example/src/HomePage.react.js
+++ b/example/src/HomePage.react.js
@@ -31,7 +31,7 @@ function Home() {
   return (
     <SiteWrapper>
       <Page.Content>
-        <Page.Header>Dashboard</Page.Header>
+        <Page.Header title="Dashboard" />
         <Grid.Row cards={true}>
           <Grid.Col width={6} sm={4} lg={2}>
             <StatsCard layout={1} movement={6} total="43" label="New Tickets" />

--- a/example/src/HomePage.react.js
+++ b/example/src/HomePage.react.js
@@ -30,8 +30,7 @@ import SiteWrapper from "./SiteWrapper.react";
 function Home() {
   return (
     <SiteWrapper>
-      <Page.Content>
-        <Page.Header title="Dashboard" />
+      <Page.Content title="Dashboard">
         <Grid.Row cards={true}>
           <Grid.Col width={6} sm={4} lg={2}>
             <StatsCard layout={1} movement={6} total="43" label="New Tickets" />

--- a/example/src/components/StoreCardsPage.react.js
+++ b/example/src/components/StoreCardsPage.react.js
@@ -10,7 +10,7 @@ function StoreCardsPage(): React.Node {
   return (
     <SiteWrapper>
       <Page.Content>
-        <Page.Header>Store Components</Page.Header>
+        <Page.Header title="Store Components" />
         <Grid.Row>
           <Grid.Col lg={3}>
             <StoreCard

--- a/example/src/components/StoreCardsPage.react.js
+++ b/example/src/components/StoreCardsPage.react.js
@@ -9,8 +9,7 @@ import SiteWrapper from "../SiteWrapper.react";
 function StoreCardsPage(): React.Node {
   return (
     <SiteWrapper>
-      <Page.Content>
-        <Page.Header title="Store Components" />
+      <Page.Content title="Store Components">
         <Grid.Row>
           <Grid.Col lg={3}>
             <StoreCard

--- a/example/src/documentation/DocsPageWrapper.react.js
+++ b/example/src/documentation/DocsPageWrapper.react.js
@@ -13,7 +13,7 @@ function DocsPageWrapper(props: Props) {
   return (
     <SiteWrapper>
       <Page.ContentWithSidebar
-        header={<Page.Header>Documentation</Page.Header>}
+        header={<Page.Header title="Documentation" />}
         sidebar={<Sidebar />}
       >
         <Card>

--- a/example/src/interface/PricingCardsPage.react.js
+++ b/example/src/interface/PricingCardsPage.react.js
@@ -10,7 +10,7 @@ function PricingCardsPage(): React.Node {
   return (
     <SiteWrapper>
       <Page.Content>
-        <Page.Header>Pricing cards</Page.Header>
+        <Page.Header title="Pricing cards" />
         <Grid.Row>
           <Grid.Col sm={6} lg={3}>
             <PricingCard>

--- a/example/src/interface/PricingCardsPage.react.js
+++ b/example/src/interface/PricingCardsPage.react.js
@@ -9,8 +9,7 @@ import SiteWrapper from "../SiteWrapper.react";
 function PricingCardsPage(): React.Node {
   return (
     <SiteWrapper>
-      <Page.Content>
-        <Page.Header title="Pricing cards" />
+      <Page.Content title="Pricing cards">
         <Grid.Row>
           <Grid.Col sm={6} lg={3}>
             <PricingCard>

--- a/src/components/Page/PageContent.react.js
+++ b/src/components/Page/PageContent.react.js
@@ -3,17 +3,32 @@
 import * as React from "react";
 import cn from "classnames";
 import { Container } from "../";
+import PageHeader from "./PageHeader.react";
 
 type Props = {|
   +children?: React.Node,
   +className?: string,
+  +title?: string,
+  +subTitle?: string,
+  +options?: React.Node,
 |};
 
-function PageContent({ className, children }: Props): React.Node {
+function PageContent({
+  className,
+  children,
+  title,
+  subTitle,
+  options,
+}: Props): React.Node {
   const classes = cn("page-content", className);
   return (
     <div className={classes}>
-      <Container>{children}</Container>
+      <Container>
+        {(title || subTitle || options) && (
+          <PageHeader title={title} subTitle={subTitle} options={options} />
+        )}
+        {children}
+      </Container>
     </div>
   );
 }

--- a/src/components/Page/PageHeader.react.js
+++ b/src/components/Page/PageHeader.react.js
@@ -2,15 +2,23 @@
 
 import * as React from "react";
 import PageTitle from "./PageTitle.react";
+import PageSubTitle from "./PageSubTitle.react";
+import PageOptions from "./PageOptions.react";
 
 type Props = {|
   +children?: React.Node,
+  +title?: string,
+  +subTitle?: string,
+  +options?: React.Node,
 |};
 
-function PageHeader({ children }: Props): React.Node {
+function PageHeader({ children, title, subTitle, options }: Props): React.Node {
   return (
     <div className="page-header">
-      <PageTitle>{children}</PageTitle>
+      {title && <PageTitle>{title}</PageTitle>}
+      {subTitle && <PageSubTitle>{subTitle}</PageSubTitle>}
+      {options && <PageOptions>{options}</PageOptions>}
+      {children}
     </div>
   );
 }

--- a/src/components/Page/PageOptions.react.js
+++ b/src/components/Page/PageOptions.react.js
@@ -1,0 +1,15 @@
+// @flow
+
+import * as React from "react";
+
+type Props = {|
+  +children?: React.Node,
+|};
+
+function PageOptions({ children }: Props): React.Node {
+  return <div class="page-options d-flex">{children}</div>;
+}
+
+PageOptions.displayName = "Page.Options";
+
+export default PageOptions;

--- a/src/components/Page/PageSubTitle.react.js
+++ b/src/components/Page/PageSubTitle.react.js
@@ -1,0 +1,15 @@
+// @flow
+
+import * as React from "react";
+
+type Props = {|
+  +children?: React.Node,
+|};
+
+function PageSubTitle({ children }: Props): React.Node {
+  return <div class="page-subtitle">{children}</div>;
+}
+
+PageSubTitle.displayName = "Page.SubTitle";
+
+export default PageSubTitle;


### PR DESCRIPTION
Adds title, subTitle and options props to Page.Header and Page.Content for props based building of page header.

Example:
```jsx
<Page.Content title='Hello' subTitle='World' options={<Button>Something</Button>} />
```