### PR TITLE
fix(Button): inputs cannot have children

### DIFF
--- a/example/src/documentation/DocsButtonsPage.react.js
+++ b/example/src/documentation/DocsButtonsPage.react.js
@@ -110,7 +110,7 @@ function DocsButtonsPage(): React.Node {
             disabled
             RootComponent="input"
             type="button"
-            // value="Input"
+            value="Input"
           />
         </Button.List>
       </ComponentDemo>

--- a/src/components/Button/Button.react.js
+++ b/src/components/Button/Button.react.js
@@ -114,9 +114,7 @@ const Button = (props: Props): React.Node => {
     const { type, value, onClick } = props;
 
     return (
-      <input {...propsForAll} type={type} value={value} onClick={onClick}>
-        {childrenForAll}
-      </input>
+      <input {...propsForAll} type={type} value={value} onClick={onClick} />
     );
   } else if (props.RootComponent === "a") {
     const { href, target, onClick } = props;


### PR DESCRIPTION
https://tabler.github.io/tabler-react/docs/buttons currently throws an error

```
input is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.
```