### PR TITLE
Adding precommit hook for flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "precommit":
-      "pretty-quick --staged && lint-staged && cd scripts && python propscheck.py",
+      "pretty-quick --staged && lint-staged && cd scripts && python propscheck.py && cd .. && ./scripts/runflow",
     "format": "prettier --write \"+(src|example)/**/*.js\"",
     "lint": "eslint --ext .js src/**/*"
   },

--- a/scripts/runflow
+++ b/scripts/runflow
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+yarn flow version > /dev/null 2>&1
+uses_yarn=$?
+
+npm run flow version > /dev/null 2>&1
+uses_npm=$?
+
+if [ $uses_yarn -eq 0 ]; then
+  yarn flow
+elif [ $uses_npm -eq 0 ]; then
+  npm run flow
+else
+  echo "Error! Neither yarn nor npm provide flow.  Consider running yarn install or npm install"
+  exit 1
+fi


### PR DESCRIPTION
This adds a precommit hook for flow.  Script checks for npm or yarn then uses the appropriate one to run flow.  Precommit will fail if flow has exit code of anything but zero or if neither npm nor yarn provide flow.

We could run this on specific files using the `flow force-recheck filename1 filename2 ...` command, but might as well check to make sure no files have errors by just running `flow`.  Let me know your thoughts on this @jonthomp 

This resolves #115 