### PR TITLE
Moves inline style to Tabs.css

### DIFF
--- a/src/components/Tabs/Tabs.css
+++ b/src/components/Tabs/Tabs.css
@@ -1,0 +1,3 @@
+.margin-bottom-24 {
+  margin-bottom: 24px !important;
+}

--- a/src/components/Tabs/Tabs.react.js
+++ b/src/components/Tabs/Tabs.react.js
@@ -6,6 +6,8 @@ import Tab from "./Tab.react";
 import TabbedContainer from "./TabbedContainer.react";
 import TabbedHeader from "./TabbedHeader.react";
 
+import styles from "./Tabs.css";
+
 type Props = {|
   +initialTab: string,
   +children: React.ChildrenArray<React.Element<typeof Tab>>,
@@ -31,7 +33,7 @@ class Tabs extends React.PureComponent<Props, State> {
         >
           {children}
         </TabbedHeader>
-        <div style={{ marginTop: "24px" }} />
+        <div className={`${styles["margin-bottom-24"]}`} />
         <TabbedContainer selectedTitle={selectedTitle}>
           {children}
         </TabbedContainer>


### PR DESCRIPTION
This moves the inline style for adding some space below the tabs, into a separate Tab.css file.

To make sure CSS modules hashed classNames are always being attached to their components, we need to use this method for adding className strings into props:

Use a named import which turns the classNames into a js object we can use:
```js
import styles from './ComponentStyles.css';
```

In ComponentStyles.css:
```css
.margin-bottom-24 {
  margin-bottom: 24px !important;
}
```

Then we can use template literals to make sure the component receives the correct hashed className:

```jsx
className={`someClassName ${styles["margin-bottom-24"]}`}
```

Or using classnames library:
```jsx
const classes = cn(styles["margin-bottom-24"], 'someClassName');
```