### PR TITLE
Missing Dropdown Props 

### DIFF
--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -58,6 +58,8 @@ type WithItemsObjectProp = {|
     +badgeType?: string,
     +value?: string,
     +isDivider?: boolean,
+    +to?: string,
+    +RootComponent?: React.ElementType,
   }>,
   +dropdownMenuClassName?: string,
   +position?: string,
@@ -113,6 +115,8 @@ function Dropdown(props: Props): React.Node {
               badgeType={item.badgeType}
               value={item.value}
               key={i}
+              to={item.to}
+              RootComponent={item.RootComponent}
             />
           )
       ));


### PR DESCRIPTION
There are some missing props such as **to** and  **RootComponent** in **Dropdown** component.
We will need these props when Dropdown have navigation functionality. 
