### PR TITLE
NavItem subnav Dropdown positioning

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -998,7 +998,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
+babel-runtime@6.26.0, babel-runtime@6.x.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1928,6 +1928,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-context@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
 
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -3024,7 +3031,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.16:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -3442,6 +3449,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -5740,7 +5751,7 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
-popper.js@^1.14.3:
+popper.js@^1.14.1, popper.js@^1.14.3:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
 
@@ -6370,6 +6381,17 @@ react-icons@^2.2.7:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   dependencies:
     react-icon-base "2.1.0"
+
+react-popper@^1.0.0-beta.6:
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.0-beta.6.tgz#cb27a2ac56adccbaf5f9c4132387289069240834"
+  dependencies:
+    babel-runtime "6.x.x"
+    create-react-context "^0.2.1"
+    popper.js "^1.14.1"
+    prop-types "^15.6.1"
+    typed-styles "^0.0.5"
+    warning "^3.0.0"
 
 react-router-dom@^4.2.2:
   version "4.2.2"
@@ -7770,6 +7792,10 @@ type-is@~1.6.15, type-is@~1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
+
+typed-styles@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
 
 typedarray@^0.0.6:
   version "0.0.6"

--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -7,13 +7,9 @@ import DropdownMenu from "./DropdownMenu.react";
 import DropdownItem from "./DropdownItem.react";
 import DropdownItemDivider from "./DropdownItemDivider.react";
 
-import { Manager, Reference, Popper } from "react-popper";
+import { Manager } from "react-popper";
 
-import type {
-  PopperChildrenProps,
-  Placement,
-  ReferenceChildrenProps,
-} from "react-popper";
+import type { Placement } from "react-popper";
 
 type DefaultProps = {|
   +children?: React.Node,
@@ -180,23 +176,18 @@ class Dropdown extends React.Component<Props, State> {
         } = this.props;
 
         return (
-          <Reference>
-            {({ ref }: ReferenceChildrenProps) => (
-              <DropdownTrigger
-                rootRef={ref}
-                isNavLink={isNavLink}
-                icon={icon}
-                type={type}
-                className={triggerClassName}
-                isOption={isOption}
-                color={color}
-                toggle={toggle}
-                onClick={this._handleTriggerOnClick}
-              >
-                {triggerContent}
-              </DropdownTrigger>
-            )}
-          </Reference>
+          <DropdownTrigger
+            isNavLink={isNavLink}
+            icon={icon}
+            type={type}
+            className={triggerClassName}
+            isOption={isOption}
+            color={color}
+            toggle={toggle}
+            onClick={this._handleTriggerOnClick}
+          >
+            {triggerContent}
+          </DropdownTrigger>
         );
       }
       return null;
@@ -234,34 +225,15 @@ class Dropdown extends React.Component<Props, State> {
           dropdownMenuClassName,
         } = this.props;
         return (
-          <Popper
-            placement={position}
-            eventsEnabled={true}
-            positionFixed={false}
+          <DropdownMenu
+            position={position}
+            arrow={arrow}
+            arrowPosition={arrowPosition}
+            className={dropdownMenuClassName}
+            show={this.state.isOpen}
           >
-            {({
-              ref,
-              style,
-              placement,
-              arrowProps,
-              scheduleUpdate,
-            }: PopperChildrenProps) => {
-              scheduleUpdate();
-              return (
-                <DropdownMenu
-                  position={placement}
-                  arrow={arrow}
-                  arrowPosition={arrowPosition}
-                  className={dropdownMenuClassName}
-                  rootRef={ref}
-                  style={style}
-                  show={this.state.isOpen}
-                >
-                  {items}
-                </DropdownMenu>
-              );
-            }}
-          </Popper>
+            {items}
+          </DropdownMenu>
         );
       }
       return null;

--- a/src/components/Dropdown/DropdownMenu.react.js
+++ b/src/components/Dropdown/DropdownMenu.react.js
@@ -2,8 +2,9 @@
 
 import * as React from "react";
 import cn from "classnames";
+import { Popper } from "react-popper";
 
-import type { Placement } from "react-popper";
+import type { Placement, PopperChildrenProps } from "react-popper";
 
 import type { Style } from "typed-styles";
 type StyleOffsets = { top: number, left: number };
@@ -52,14 +53,27 @@ function DropdownMenu({
     className
   );
   return (
-    <div
-      className={classes}
-      data-placement={position}
-      style={style}
-      ref={rootRef}
-    >
-      {children}
-    </div>
+    <Popper placement={position} eventsEnabled={true} positionFixed={false}>
+      {({
+        ref,
+        style,
+        placement,
+        arrowProps,
+        scheduleUpdate,
+      }: PopperChildrenProps) => {
+        scheduleUpdate();
+        return (
+          <div
+            className={classes}
+            data-placement={placement}
+            style={style}
+            ref={ref}
+          >
+            {children}
+          </div>
+        );
+      }}
+    </Popper>
   );
 }
 

--- a/src/components/Dropdown/DropdownMenu.react.js
+++ b/src/components/Dropdown/DropdownMenu.react.js
@@ -54,13 +54,7 @@ function DropdownMenu({
   );
   return (
     <Popper placement={position} eventsEnabled={true} positionFixed={false}>
-      {({
-        ref,
-        style,
-        placement,
-        arrowProps,
-        scheduleUpdate,
-      }: PopperChildrenProps) => {
+      {({ ref, style, placement, scheduleUpdate }: PopperChildrenProps) => {
         scheduleUpdate();
         return (
           <div

--- a/src/components/Dropdown/DropdownTrigger.react.js
+++ b/src/components/Dropdown/DropdownTrigger.react.js
@@ -4,6 +4,9 @@ import * as React from "react";
 import cn from "classnames";
 import { Button, Icon } from "../";
 
+import { Reference } from "react-popper";
+import type { ReferenceChildrenProps } from "react-popper";
+
 type Props = {|
   +children?: React.Node,
   +className?: string,
@@ -76,20 +79,28 @@ function DropdownTrigger({
   );
 
   return type === "link" ? (
-    <a className={classes} onClick={onClick} ref={rootRef}>
-      {childrenFragment}
-    </a>
+    <Reference>
+      {({ ref }: ReferenceChildrenProps) => (
+        <a className={classes} onClick={onClick} ref={ref}>
+          {childrenFragment}
+        </a>
+      )}
+    </Reference>
   ) : (
-    <Button
-      className={classes}
-      color={color}
-      isDropdownToggle
-      isOption={isOption}
-      onClick={onClick}
-      rootRef={rootRef}
-    >
-      {childrenFragment}
-    </Button>
+    <Reference>
+      {({ ref }: ReferenceChildrenProps) => (
+        <Button
+          className={classes}
+          color={color}
+          isDropdownToggle
+          isOption={isOption}
+          onClick={onClick}
+          rootRef={ref}
+        >
+          {childrenFragment}
+        </Button>
+      )}
+    </Reference>
   );
 }
 

--- a/src/components/Nav/NavItem.react.js
+++ b/src/components/Nav/NavItem.react.js
@@ -70,8 +70,7 @@ class NavItem extends React.PureComponent<Props, State> {
       position = "bottom-start",
     }: Props = this.props;
 
-    const hasSubNav: boolean =
-      forcedHasSubNav || !!subItems || !!subItemsObjects;
+    const hasSubNav = forcedHasSubNav || !!subItems || !!subItemsObjects;
 
     const navLink =
       (typeof children === "string" || value) && hasSubNav ? (

--- a/src/components/Nav/NavLink.react.js
+++ b/src/components/Nav/NavLink.react.js
@@ -11,6 +11,7 @@ type Props = {|
   +icon?: string,
   +to?: string,
   +hasSubNav?: boolean,
+  +rootRef?: (?HTMLElement) => void,
 |};
 
 function NavLink({
@@ -21,6 +22,7 @@ function NavLink({
   active = false,
   to,
   hasSubNav,
+  rootRef,
 }: Props): React.Node {
   const classes = cn({ "nav-link": true, active: active }, className);
 
@@ -40,7 +42,7 @@ function NavLink({
       {childrenForAll}
     </RootComponent>
   ) : (
-    <a className={classes} href={to}>
+    <a className={classes} href={to} ref={rootRef}>
       {childrenForAll}
     </a>
   );


### PR DESCRIPTION
This uses react-popper for the positioning of the `Dropdown`s created for `NavItem` subnav items.

In order to help with this, the `Reference` and `Popper` components within `Dropdown` have been moved into `Dropdown.Trigger` and `Dropdown.Menu`

![screenshot from 2018-05-14 18-49-25](https://user-images.githubusercontent.com/660222/40014176-bf017414-57a7-11e8-85ec-900045e12931.png)
