### PR TITLE
Add AccountDropdown

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.examples.md
+++ b/src/components/AccountDropdown/AccountDropdown.examples.md
@@ -1,0 +1,16 @@
+```jsx
+<AccountDropdown
+  avatarURL="./demo/faces/female/25.jpg"
+  name="Jane Pearson"
+  description="Administrator"
+  options={[
+    "profile",
+    "settings",
+    "mail",
+    "message",
+    "divider",
+    "help",
+    "logout",
+  ]}
+/>
+```

--- a/src/components/AccountDropdown/AccountDropdown.examples.md
+++ b/src/components/AccountDropdown/AccountDropdown.examples.md
@@ -5,7 +5,7 @@
   description="Administrator"
   options={[
     "profile",
-    "settings",
+    { icon: "settings", value: "Settings", to: "/settings" },
     "mail",
     "message",
     "divider",

--- a/src/components/AccountDropdown/AccountDropdown.react.js
+++ b/src/components/AccountDropdown/AccountDropdown.react.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from "react";
+import { Dropdown, Avatar } from "../";
+
+import type { itemObject } from "../Dropdown/Dropdown.react";
+
+type defaultOptionType =
+  | "profile"
+  | "settings"
+  | "mail"
+  | "message"
+  | "divider"
+  | "help"
+  | "logout";
+
+type optionsType = Array<defaultOptionType | itemObject>;
+
+type defaultOptionsType = { [defaultOptionType]: itemObject };
+
+type Props = {|
+  +avatarURL?: string,
+  +name?: string,
+  +description?: string,
+  +options?: optionsType,
+|};
+
+const defaultOptions: defaultOptionsType = {
+  profile: { icon: "user", value: "Profile", to: "/profile" },
+  settings: { icon: "settings", value: "Settings", to: "/settings" },
+  mail: { icon: "mail", value: "Inbox", badge: "6", to: "/mail" },
+  message: { icon: "send", value: "Message", to: "/message" },
+  help: { icon: "help-circle", value: "Need help?", to: "/help" },
+  logout: { icon: "log-out", value: "Sign out", to: "/logout" },
+  divider: { isDivider: true },
+};
+
+const itemsFromDefaultOptions = (options: optionsType) =>
+  options.map(opt => (typeof opt === "string" ? defaultOptions[opt] : opt));
+
+function AccountDropdown({
+  avatarURL,
+  name,
+  description,
+  options,
+}: Props): React.Node {
+  const itemsObjects = itemsFromDefaultOptions(defaultOptions);
+
+  return (
+    <Dropdown
+      isNavLink
+      triggerClassName="pr-0 leading-none"
+      triggerContent={
+        <React.Fragment>
+          <Avatar imageURL={avatarURL} />
+          <span className="ml-2 d-none d-lg-block">
+            <span className="text-default">{name}</span>
+            <small className="text-muted d-block mt-1">{description}</small>
+          </span>
+        </React.Fragment>
+      }
+      position="bottom-end"
+      arrow={true}
+      arrowPosition="right"
+      toggle={false}
+      itemsObject={itemsObjects}
+    />
+  );
+}
+
+export default AccountDropdown;

--- a/src/components/AccountDropdown/AccountDropdown.react.js
+++ b/src/components/AccountDropdown/AccountDropdown.react.js
@@ -21,13 +21,21 @@ type Props = {|
   +avatarURL?: string,
   +name?: string,
   +description?: string,
+  /**
+   * An array of the option items within the Dropdown
+   */
   +options?: optionsType,
+  /**
+   * The default RootComponent for all options.
+   * optionsObjects[x].RootComponent takes priority
+   */
+  +optionsRootComponent?: React.ElementType,
 |};
 
 const defaultOptions: defaultOptionsType = {
   profile: { icon: "user", value: "Profile", to: "/profile" },
   settings: { icon: "settings", value: "Settings", to: "/settings" },
-  mail: { icon: "mail", value: "Inbox", badge: "6", to: "/mail" },
+  mail: { icon: "mail", value: "Inbox", to: "/mail" },
   message: { icon: "send", value: "Message", to: "/message" },
   help: { icon: "help-circle", value: "Need help?", to: "/help" },
   logout: { icon: "log-out", value: "Sign out", to: "/logout" },
@@ -37,13 +45,17 @@ const defaultOptions: defaultOptionsType = {
 const itemsFromDefaultOptions = (options: optionsType) =>
   options.map(opt => (typeof opt === "string" ? defaultOptions[opt] : opt));
 
+/**
+ * A component for fast creation of an account centric dropdown
+ */
 function AccountDropdown({
   avatarURL,
   name,
   description,
-  options,
+  options = [],
+  optionsRootComponent,
 }: Props): React.Node {
-  const itemsObjects = itemsFromDefaultOptions(defaultOptions);
+  const itemsObjects = itemsFromDefaultOptions(options);
 
   return (
     <Dropdown
@@ -63,6 +75,7 @@ function AccountDropdown({
       arrowPosition="right"
       toggle={false}
       itemsObject={itemsObjects}
+      itemsRootComponent={optionsRootComponent}
     />
   );
 }

--- a/src/components/AccountDropdown/index.js
+++ b/src/components/AccountDropdown/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+import AccountDropdown from "./AccountDropdown.react";
+
+export { AccountDropdown as default };

--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -102,6 +102,16 @@ type WithItemsProps = {|
   +arrowPosition?: "left" | "right",
 |};
 
+export type itemObject = {|
+  +icon?: string,
+  +badge?: string,
+  +badgeType?: string,
+  +value?: string,
+  +isDivider?: boolean,
+  +to?: string,
+  +RootComponent?: React.ElementType,
+|};
+
 type WithItemsObjectProp = {|
   ...DefaultProps,
   ...WithAnyTriggerProps,
@@ -112,15 +122,7 @@ type WithItemsObjectProp = {|
   /**
    * The items for this Dropdowns menu in object form
    */
-  +itemsObject: Array<{
-    +icon?: string,
-    +badge?: string,
-    +badgeType?: string,
-    +value?: string,
-    +isDivider?: boolean,
-    +to?: string,
-    +RootComponent?: React.ElementType,
-  }>,
+  +itemsObject: Array<itemObject>,
   /**
    * Any additional classNames for the DropdownMenu
    */

--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -126,6 +126,11 @@ type WithItemsObjectProp = {|
   +position?: Placement,
   +arrow?: boolean,
   +arrowPosition?: "left" | "right",
+  /**
+   * The default RootComponent for all itemsObjects.
+   * itemsObjects[x].RootComponent takes priority
+   */
+  +itemsRootComponent?: React.ElementType,
 |};
 
 type Props =
@@ -198,7 +203,8 @@ class Dropdown extends React.Component<Props, State> {
     const items = (() => {
       if (this.props.items) return this.props.items;
       if (this.props.itemsObject) {
-        return this.props.itemsObject.map(
+        const { itemsObject, itemsRootComponent } = this.props;
+        return itemsObject.map(
           (item, i) =>
             item.isDivider ? (
               <Dropdown.ItemDivider key={i} />
@@ -210,7 +216,7 @@ class Dropdown extends React.Component<Props, State> {
                 value={item.value}
                 key={i}
                 to={item.to}
-                RootComponent={item.RootComponent}
+                RootComponent={item.RootComponent || itemsRootComponent}
               />
             )
         );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+export { default as AccountDropdown } from "./AccountDropdown";
 export { default as Alert } from "./Alert";
 export { default as Avatar } from "./Avatar";
 export { default as Badge } from "./Badge";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -15,6 +15,10 @@ module.exports = {
       name: "Components",
       sections: [
         {
+          name: "Account Dropdown",
+          components: "src/components/AccountDropdown/**/*.react.{js,jsx}",
+        },
+        {
           name: "Alert",
           components: "src/components/Alert/**/*.react.{js,jsx}",
         },


### PR DESCRIPTION
Adds a component for easily replicating the Avatar/user dropdown seen in the top right hand corner of the demo website.

Also adds a new prop to `Dropdown` to allow setting of the default RootComponent to be used with `DropdownItem`s generated from the `itemsObject` prop.

![screenshot from 2018-05-15 19-50-57](https://user-images.githubusercontent.com/660222/40077673-4a54a6a8-587a-11e8-9211-7bd187153cf9.png)
