### PR TITLE
SiteWrapper

### DIFF
--- a/example/src/SiteWrapper.react.js
+++ b/example/src/SiteWrapper.react.js
@@ -3,17 +3,7 @@
 import * as React from "react";
 import { NavLink } from "react-router-dom";
 
-import {
-  Page,
-  Site,
-  Button,
-  Nav,
-  Dropdown,
-  Avatar,
-  Grid,
-  Text,
-  Icon,
-} from "tabler-react";
+import { Site } from "tabler-react";
 
 type Props = {|
   +children: React.Node,
@@ -96,154 +86,50 @@ const navBarItems: Array<navItem> = [
   },
 ];
 
+const notificationsObjects = [
+  {
+    avatarURL: "demo/faces/male/41.jpg",
+    message: (
+      <React.Fragment>
+        <strong>Nathan</strong> pushed new commit: Fix page load performance
+        issue.
+      </React.Fragment>
+    ),
+    time: "10 minutes ago",
+  },
+  {
+    avatarURL: "demo/faces/female/1.jpg",
+    message: (
+      <React.Fragment>
+        <strong>Alice</strong> started new task: Tabler UI design.
+      </React.Fragment>
+    ),
+    time: "1 hour ago",
+  },
+  {
+    avatarURL: "demo/faces/female/18.jpg",
+    message: (
+      <React.Fragment>
+        <strong>Rose</strong> deployed new version of NodeJS REST Api // V3
+      </React.Fragment>
+    ),
+    time: "2 hours ago",
+  },
+];
+
 class SiteWrapper extends React.Component<Props, void> {
   render(): React.Node {
     return (
-      <Page>
-        <Page.Main>
-          <Site.Header>
-            <Site.Logo
-              href={"/"}
-              alt="Tabler React"
-              src="./demo/brand/tabler.svg"
-            />
-            <div className="d-flex order-lg-2 ml-auto">
-              <Nav.Item type="div" className="d-none d-md-flex">
-                <Button
-                  href="https://github.com/tabler/tabler-react"
-                  target="_blank"
-                  outline
-                  size="sm"
-                  RootComponent="a"
-                  color="primary"
-                >
-                  Source code
-                </Button>
-              </Nav.Item>
-
-              <Dropdown
-                triggerContent={<span className="nav-unread" />}
-                isNavLink={true}
-                toggle={false}
-                icon="bell"
-                desktopOnly
-                items={
-                  <React.Fragment>
-                    <Dropdown.Item className="d-flex">
-                      <Avatar
-                        className="mr-3 align-self-center"
-                        imageURL="demo/faces/male/41.jpg"
-                      />
-                      <div>
-                        <strong>Nathan</strong> pushed new commit: Fix page load
-                        performance issue.
-                        <Text color="muted" size="small">
-                          10 minutes ago
-                        </Text>
-                      </div>
-                    </Dropdown.Item>
-                    <Dropdown.Item className=" d-flex">
-                      <Avatar
-                        className="mr-3 align-self-center"
-                        imageURL={"demo/faces/female/1.jpg"}
-                      />
-                      <div>
-                        <strong>Alice</strong> started new task: Tabler UI
-                        design.
-                        <Text color="muted" size="small">
-                          1 hour ago
-                        </Text>
-                      </div>
-                    </Dropdown.Item>
-                    <Dropdown.Item className="d-flex">
-                      <Avatar
-                        className="mr-3 align-self-center"
-                        imageURL={"demo/faces/female/18.jpg"}
-                      />
-                      <div>
-                        <strong>Rose</strong> deployed new version of NodeJS
-                        REST Api V3
-                        <Text color="muted" size="small">
-                          2 hours ago
-                        </Text>
-                      </div>
-                    </Dropdown.Item>
-                    <Dropdown.ItemDivider />
-                    <Dropdown.Item className="text-center text-muted-dark">
-                      Mark all as read
-                    </Dropdown.Item>
-                  </React.Fragment>
-                }
-                position="bottom-end"
-                arrow={true}
-                arrowPosition="right"
-              />
-
-              <Dropdown
-                isNavLink
-                triggerClassName="pr-0 leading-none"
-                triggerContent={
-                  <React.Fragment>
-                    <Avatar imageURL={"./demo/faces/female/25.jpg"} />
-                    <span className="ml-2 d-none d-lg-block">
-                      <span className="text-default">Jane Pearson</span>
-                      <small className="text-muted d-block mt-1">
-                        Administrator
-                      </small>
-                    </span>
-                  </React.Fragment>
-                }
-                position="bottom-end"
-                arrow={true}
-                arrowPosition="right"
-                toggle={false}
-                itemsObject={[
-                  { icon: "user", value: "Profile" },
-                  { icon: "settings", value: "Settings" },
-                  { icon: "mail", value: "Inbox", badge: "6" },
-                  { icon: "send", value: "Message" },
-                  { isDivider: true },
-                  { icon: "help-circle", value: "Need help?" },
-                  { icon: "log-out", value: "Sign out" },
-                ]}
-              />
-            </div>
-            <a
-              className="header-toggler d-lg-none ml-3 ml-lg-0"
-              data-toggle="collapse"
-              data-target="#headerMenuCollapse"
-            >
-              <span className="header-toggler-icon" />
-            </a>
-          </Site.Header>
-          <Site.Nav>
-            <Grid.Row className="align-items-center">
-              <Grid.Col lg={3} className="ml-auto">
-                <form className="input-icon my-3 my-lg-0">
-                  <input
-                    type="search"
-                    className="form-control header-search"
-                    placeholder="Search&hellip;"
-                    tabIndex="1"
-                  />
-                  <div className="input-icon-addon">
-                    <Icon prefix="fe" name="search" />
-                  </div>
-                </form>
-              </Grid.Col>
-              <Grid.Col className="col-lg order-lg-first">
-                <Nav
-                  tabbed
-                  className="border-0 flex-column flex-lg-row"
-                  itemsObjects={navBarItems}
-                />
-              </Grid.Col>
-            </Grid.Row>
-          </Site.Nav>
-          {this.props.children}
-        </Page.Main>
-        <Site.Footer />
-      </Page>
+      <Site.Wrapper
+        href={"/"}
+        alt="Tabler React"
+        imageURL="./demo/brand/tabler.svg"
+        withNotifications={true}
+        notificationsObjects={notificationsObjects}
+        itemsObjects={navBarItems}
+      >
+        {this.props.children}
+      </Site.Wrapper>
     );
   }
 }

--- a/example/src/SiteWrapper.react.js
+++ b/example/src/SiteWrapper.react.js
@@ -117,16 +117,33 @@ const notificationsObjects = [
   },
 ];
 
+const accountDropdownProps = {
+  avatarURL: "./demo/faces/female/25.jpg",
+  name: "Jane Pearson",
+  description: "Administrator",
+  options: [
+    { icon: "user", value: "Profile" },
+    { icon: "settings", value: "Settings" },
+    { icon: "mail", value: "Inbox", badge: "6" },
+    { icon: "send", value: "Message" },
+    { isDivider: true },
+    { icon: "help-circle", value: "Need help?" },
+    { icon: "log-out", value: "Sign out" },
+  ],
+};
+
 class SiteWrapper extends React.Component<Props, void> {
   render(): React.Node {
     return (
       <Site.Wrapper
-        href={"/"}
-        alt="Tabler React"
-        imageURL="./demo/brand/tabler.svg"
-        withNotifications={true}
-        notificationsObjects={notificationsObjects}
-        itemsObjects={navBarItems}
+        headerProps={{
+          href: "/",
+          alt: "Tabler React",
+          imageURL: "./demo/brand/tabler.svg",
+          notificationsTray: { notificationsObjects },
+          accountDropdown: accountDropdownProps,
+        }}
+        navProps={{ itemsObjects: navBarItems }}
       >
         {this.props.children}
       </Site.Wrapper>

--- a/src/components/AccountDropdown/AccountDropdown.react.js
+++ b/src/components/AccountDropdown/AccountDropdown.react.js
@@ -17,7 +17,7 @@ type optionsType = Array<defaultOptionType | itemObject>;
 
 type defaultOptionsType = { [defaultOptionType]: itemObject };
 
-type Props = {|
+export type Props = {|
   +avatarURL?: string,
   +name?: string,
   +description?: string,

--- a/src/components/Form/FormMaskedInput.react.js
+++ b/src/components/Form/FormMaskedInput.react.js
@@ -4,7 +4,7 @@ import cn from "classnames";
 import MaskedInput from "react-text-mask";
 
 type Props = {|
-  +mask: ({ [string]: string }) => {} | Array<string>,
+  +mask: Array<string | RegExp>,
   +className?: string,
   +placeholder?: string,
   +guide?: boolean,

--- a/src/components/Notification/NotificationTray.react.js
+++ b/src/components/Notification/NotificationTray.react.js
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Notification, Dropdown } from "../";
 import type { Props as NotificationProps } from "./Notification.react";
 
-type Props = {|
+export type Props = {|
   /**
    * Notification components
    */

--- a/src/components/Site/Site.react.js
+++ b/src/components/Site/Site.react.js
@@ -5,11 +5,15 @@ import SiteHeader from "./SiteHeader.react";
 import SiteFooter from "./SiteFooter.react";
 import SiteNav from "./SiteNav.react";
 import SiteLogo from "./SiteLogo.react";
+import SiteWrapper from "./SiteWrapper.react";
 
 type Props = {|
   +children: React.Node,
 |};
 
+/**
+ * Components for building the base of your website, such as a header, footer and nav bar
+ */
 function Site(props: Props): React.Node {
   return props.children;
 }
@@ -18,6 +22,7 @@ Site.Header = SiteHeader;
 Site.Footer = SiteFooter;
 Site.Nav = SiteNav;
 Site.Logo = SiteLogo;
+Site.Wrapper = SiteWrapper;
 
 Site.displayName = "Site";
 

--- a/src/components/Site/SiteHeader.react.js
+++ b/src/components/Site/SiteHeader.react.js
@@ -3,13 +3,14 @@
 import * as React from "react";
 import {
   Container,
-  Avatar,
   Site,
   Nav,
   Button,
-  Dropdown,
   Notification,
+  AccountDropdown,
 } from "../";
+import type { Props as NotificationTrayProps } from "../Notification/NotificationTray.react";
+import type { Props as AccountDropdownProps } from "../AccountDropdown/AccountDropdown.react";
 
 export type Props = {|
   +children?: React.Node,
@@ -26,14 +27,10 @@ export type Props = {|
    */
   +alt?: string,
   /**
-   * Include the notifications tray
+   * Include a notifications tray
    */
-  +withNotifications?: boolean,
-  +notificationsObjects?: Array<{|
-    +avatarURL?: string,
-    +message: React.Node,
-    +time?: string,
-  |}>,
+  +notificationsTray?: NotificationTrayProps,
+  +accountDropdown?: AccountDropdownProps,
 |};
 
 /**
@@ -45,77 +42,55 @@ const SiteHeader = ({
   href,
   imageURL,
   alt,
-  withNotifications,
-  notificationsObjects,
-}: Props): React.Node => (
-  <div className="header py-4">
-    <Container>
-      <div className="d-flex">
-        {children || (
-          <React.Fragment>
-            <Site.Logo href={href} alt={alt} src={imageURL} />
-            <div className="d-flex order-lg-2 ml-auto">
-              <Nav.Item type="div" className="d-none d-md-flex">
-                <Button
-                  href="https://github.com/tabler/tabler-react"
-                  target="_blank"
-                  outline
-                  size="sm"
-                  RootComponent="a"
-                  color="primary"
-                >
-                  Source code
-                </Button>
-              </Nav.Item>
+  notificationsTray: notificationsTrayFromProps,
+  accountDropdown: accountDropdownFromProps,
+}: Props): React.Node => {
+  const notificationsTray =
+    notificationsTrayFromProps &&
+    React.createElement(Notification.Tray, notificationsTrayFromProps);
 
-              {withNotifications && (
-                <Notification.Tray
-                  notificationsObjects={notificationsObjects}
-                />
-              )}
+  const accountDropdown =
+    accountDropdownFromProps &&
+    React.createElement(AccountDropdown, accountDropdownFromProps);
 
-              <Dropdown
-                isNavLink
-                triggerClassName="pr-0 leading-none"
-                triggerContent={
-                  <React.Fragment>
-                    <Avatar imageURL={"./demo/faces/female/25.jpg"} />
-                    <span className="ml-2 d-none d-lg-block">
-                      <span className="text-default">Jane Pearson</span>
-                      <small className="text-muted d-block mt-1">
-                        Administrator
-                      </small>
-                    </span>
-                  </React.Fragment>
-                }
-                position="bottom-end"
-                arrow={true}
-                arrowPosition="right"
-                toggle={false}
-                itemsObject={[
-                  { icon: "user", value: "Profile" },
-                  { icon: "settings", value: "Settings" },
-                  { icon: "mail", value: "Inbox", badge: "6" },
-                  { icon: "send", value: "Message" },
-                  { isDivider: true },
-                  { icon: "help-circle", value: "Need help?" },
-                  { icon: "log-out", value: "Sign out" },
-                ]}
-              />
-            </div>
-            <a
-              className="header-toggler d-lg-none ml-3 ml-lg-0"
-              data-toggle="collapse"
-              data-target="#headerMenuCollapse"
-            >
-              <span className="header-toggler-icon" />
-            </a>
-          </React.Fragment>
-        )}
-      </div>
-    </Container>
-  </div>
-);
+  return (
+    <div className="header py-4">
+      <Container>
+        <div className="d-flex">
+          {children || (
+            <React.Fragment>
+              <Site.Logo href={href} alt={alt} src={imageURL} />
+              <div className="d-flex order-lg-2 ml-auto">
+                <Nav.Item type="div" className="d-none d-md-flex">
+                  <Button
+                    href="https://github.com/tabler/tabler-react"
+                    target="_blank"
+                    outline
+                    size="sm"
+                    RootComponent="a"
+                    color="primary"
+                  >
+                    Source code
+                  </Button>
+                </Nav.Item>
+
+                {notificationsTray}
+                {accountDropdown}
+              </div>
+              <a
+                className="header-toggler d-lg-none ml-3 ml-lg-0"
+                data-toggle="collapse"
+                data-target="#headerMenuCollapse"
+              >
+                <span className="header-toggler-icon" />
+              </a>
+            </React.Fragment>
+          )}
+        </div>
+      </Container>
+    </div>
+  );
+};
 
 SiteHeader.displayName = "Site.Header";
 

--- a/src/components/Site/SiteHeader.react.js
+++ b/src/components/Site/SiteHeader.react.js
@@ -1,16 +1,118 @@
 // @flow
 
 import * as React from "react";
-import { Container } from "../";
+import {
+  Container,
+  Avatar,
+  Site,
+  Nav,
+  Button,
+  Dropdown,
+  Notification,
+} from "../";
 
-type Props = {|
+export type Props = {|
   +children?: React.Node,
+  /**
+   * href attributefor the logo
+   */
+  +href?: string,
+  /**
+   * Logo image URL
+   */
+  +imageURL?: string,
+  /**
+   * The logo alt attribute
+   */
+  +alt?: string,
+  /**
+   * Include the notifications tray
+   */
+  +withNotifications?: boolean,
+  +notificationsObjects?: Array<{|
+    +avatarURL?: string,
+    +message: React.Node,
+    +time?: string,
+  |}>,
 |};
 
-const SiteHeader = ({ children }: Props): React.Node => (
+/**
+ * The very top header bar of your website, containing the logo and some optional
+ * action components, such as a NotificationTray or an AccountDropdown on the right hand side
+ */
+const SiteHeader = ({
+  children,
+  href,
+  imageURL,
+  alt,
+  withNotifications,
+  notificationsObjects,
+}: Props): React.Node => (
   <div className="header py-4">
     <Container>
-      <div className="d-flex">{children}</div>
+      <div className="d-flex">
+        {children || (
+          <React.Fragment>
+            <Site.Logo href={href} alt={alt} src={imageURL} />
+            <div className="d-flex order-lg-2 ml-auto">
+              <Nav.Item type="div" className="d-none d-md-flex">
+                <Button
+                  href="https://github.com/tabler/tabler-react"
+                  target="_blank"
+                  outline
+                  size="sm"
+                  RootComponent="a"
+                  color="primary"
+                >
+                  Source code
+                </Button>
+              </Nav.Item>
+
+              {withNotifications && (
+                <Notification.Tray
+                  notificationsObjects={notificationsObjects}
+                />
+              )}
+
+              <Dropdown
+                isNavLink
+                triggerClassName="pr-0 leading-none"
+                triggerContent={
+                  <React.Fragment>
+                    <Avatar imageURL={"./demo/faces/female/25.jpg"} />
+                    <span className="ml-2 d-none d-lg-block">
+                      <span className="text-default">Jane Pearson</span>
+                      <small className="text-muted d-block mt-1">
+                        Administrator
+                      </small>
+                    </span>
+                  </React.Fragment>
+                }
+                position="bottom-end"
+                arrow={true}
+                arrowPosition="right"
+                toggle={false}
+                itemsObject={[
+                  { icon: "user", value: "Profile" },
+                  { icon: "settings", value: "Settings" },
+                  { icon: "mail", value: "Inbox", badge: "6" },
+                  { icon: "send", value: "Message" },
+                  { isDivider: true },
+                  { icon: "help-circle", value: "Need help?" },
+                  { icon: "log-out", value: "Sign out" },
+                ]}
+              />
+            </div>
+            <a
+              className="header-toggler d-lg-none ml-3 ml-lg-0"
+              data-toggle="collapse"
+              data-target="#headerMenuCollapse"
+            >
+              <span className="header-toggler-icon" />
+            </a>
+          </React.Fragment>
+        )}
+      </div>
     </Container>
   </div>
 );

--- a/src/components/Site/SiteLogo.react.js
+++ b/src/components/Site/SiteLogo.react.js
@@ -3,9 +3,9 @@
 import * as React from "react";
 
 type Props = {|
-  +href: string,
-  +src: string,
-  +alt: string,
+  +href?: string,
+  +src?: string,
+  +alt?: string,
 |};
 
 const SiteLogo = (props: Props): React.Node => (

--- a/src/components/Site/SiteNav.react.js
+++ b/src/components/Site/SiteNav.react.js
@@ -1,15 +1,65 @@
 // @flow
 
 import * as React from "react";
-import { Container } from "../";
+import { Container, Grid, Nav, InlineSearchForm } from "../../";
 
-type Props = {|
-  +children?: React.Node,
+type subNavItem = {|
+  +value: string,
+  +to?: string,
+  +icon?: string,
+  +LinkComponent?: React.ElementType,
 |};
 
-const SiteNav = (props: Props): React.Node => (
+type navItem = {|
+  +value: string,
+  +to?: string,
+  +icon?: string,
+  +active?: boolean,
+  +LinkComponent?: React.ElementType,
+  +subItems?: Array<subNavItem>,
+|};
+
+type navItems = Array<navItem>;
+
+export type Props = {|
+  +children?: React.Node,
+  +items?: React.ChildrenArray<React.Element<typeof Nav.Item>>,
+  +itemsObjects?: navItems,
+  /**
+   * Display a search form to the right of the nav items
+   */
+  +withSearchForm?: boolean,
+  /**
+   * Provide your own component to replace the search form
+   */
+  +rightColumnComponent?: React.Node,
+|};
+
+const SiteNav = ({
+  children,
+  items,
+  itemsObjects,
+  withSearchForm = true,
+  rightColumnComponent,
+}: Props): React.Node => (
   <div className="header collapse d-lg-flex p-0" id="headerMenuCollapse">
-    <Container>{props.children}</Container>
+    <Container>
+      {children || (
+        <Grid.Row className="align-items-center">
+          <Grid.Col lg={3} className="ml-auto">
+            {rightColumnComponent || (withSearchForm && <InlineSearchForm />)}
+          </Grid.Col>
+          <Grid.Col className="col-lg order-lg-first">
+            <Nav
+              tabbed
+              className="border-0 flex-column flex-lg-row"
+              items={items}
+              itemsObjects={itemsObjects}
+            />
+          </Grid.Col>
+        </Grid.Row>
+      )}
+    </Container>
   </div>
 );
 

--- a/src/components/Site/SiteNav.react.js
+++ b/src/components/Site/SiteNav.react.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from "react";
-import { Container, Grid, Nav, InlineSearchForm } from "../../";
+import { Container, Grid, Nav } from "../../";
 
 type subNavItem = {|
   +value: string,
@@ -47,7 +47,9 @@ const SiteNav = ({
       {children || (
         <Grid.Row className="align-items-center">
           <Grid.Col lg={3} className="ml-auto">
-            {rightColumnComponent || (withSearchForm && <InlineSearchForm />)}
+            {/* @TODO: add InlineSearchForm  */}
+            {/* {rightColumnComponent || (withSearchForm && <InlineSearchForm />)} */}
+            {rightColumnComponent}
           </Grid.Col>
           <Grid.Col className="col-lg order-lg-first">
             <Nav

--- a/src/components/Site/SiteWrapper.react.js
+++ b/src/components/Site/SiteWrapper.react.js
@@ -6,40 +6,24 @@ import { Page, Site } from "../";
 import type { Props as SiteHeaderProps } from "./SiteHeader.react";
 import type { Props as SiteNavProps } from "./SiteNav.react";
 
-type Props = SiteHeaderProps &
-  SiteNavProps & {|
-    +children: React.Node,
-  |};
+type Props = {|
+  +headerProps: SiteHeaderProps,
+  +navProps: SiteNavProps,
+  +children: React.Node,
+|};
 
 function SiteWrapper(props: Props): React.Node {
-  const {
-    href,
-    alt,
-    imageURL,
-    withNotifications,
-    notificationsObjects,
-    items: navItems,
-    itemsObjects: navItemsObjects,
-    withSearchForm,
-    rightColumnComponent,
-  } = props;
+  const { headerProps, navProps, children } = props;
+
+  const header = React.createElement(Site.Header, headerProps);
+  const nav = React.createElement(Site.Nav, navProps);
+
   return (
     <Page>
       <Page.Main>
-        <Site.Header
-          href={href}
-          alt={alt}
-          imageURL={imageURL}
-          withNotifications={withNotifications}
-          notificationsObjects={notificationsObjects}
-        />
-        <Site.Nav
-          items={navItems}
-          itemsObjects={navItemsObjects}
-          withSearchForm={withSearchForm}
-          rightColumnComponent={rightColumnComponent}
-        />
-        {props.children}
+        {header}
+        {nav}
+        {children}
       </Page.Main>
       <Site.Footer />
     </Page>

--- a/src/components/Site/SiteWrapper.react.js
+++ b/src/components/Site/SiteWrapper.react.js
@@ -1,0 +1,51 @@
+// @flow
+
+import * as React from "react";
+
+import { Page, Site } from "../";
+import type { Props as SiteHeaderProps } from "./SiteHeader.react";
+import type { Props as SiteNavProps } from "./SiteNav.react";
+
+type Props = SiteHeaderProps &
+  SiteNavProps & {|
+    +children: React.Node,
+  |};
+
+function SiteWrapper(props: Props): React.Node {
+  const {
+    href,
+    alt,
+    imageURL,
+    withNotifications,
+    notificationsObjects,
+    items: navItems,
+    itemsObjects: navItemsObjects,
+    withSearchForm,
+    rightColumnComponent,
+  } = props;
+  return (
+    <Page>
+      <Page.Main>
+        <Site.Header
+          href={href}
+          alt={alt}
+          imageURL={imageURL}
+          withNotifications={withNotifications}
+          notificationsObjects={notificationsObjects}
+        />
+        <Site.Nav
+          items={navItems}
+          itemsObjects={navItemsObjects}
+          withSearchForm={withSearchForm}
+          rightColumnComponent={rightColumnComponent}
+        />
+        {props.children}
+      </Page.Main>
+      <Site.Footer />
+    </Page>
+  );
+}
+
+SiteWrapper.displayName = "Site.Wrapper";
+
+export default SiteWrapper;


### PR DESCRIPTION
This takes the SiteWrapper component used in the example site and creates a reusable Site.Wrapper tabler-react component. In addition, SiteHeader and SiteNav both gain new shorthand hand props.

Other bits and pieces:
- FormMaskedInput fixed type issue
- AccountDropdown and Notification prop types are now exported