### PR TITLE
Icon docs and minor amends

### DIFF
--- a/src/components/Icon/Icon.examples.md
+++ b/src/components/Icon/Icon.examples.md
@@ -2,19 +2,29 @@
 <Icon name="user" />
 ```
 
-Changing the prefix to use fontawesome
+#### Changing the prefix to use fontawesome
+
+First you need to add font awesome to your project.
+
+In your HTML <head>:
+
+```html
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+```
+
+Then use the Icon `prefix` prop
 
 ```jsx
 <Icon prefix="fa" name="user" />
 ```
 
-Rendering a flag
+#### Rendering a flag
 
 ```jsx
 <Icon prefix="flag" name="gb" />
 ```
 
-Rendering a payment icon
+#### Rendering a payment icon
 
 ```jsx
 <Icon payment name="visa" />

--- a/src/components/Icon/Icon.examples.md
+++ b/src/components/Icon/Icon.examples.md
@@ -21,7 +21,7 @@ Then use the Icon `prefix` prop
 #### Rendering a flag
 
 ```jsx
-<Icon prefix="flag" name="gb" />
+<Icon flag name="gb" />
 ```
 
 #### Rendering a payment icon

--- a/src/components/Icon/Icon.react.js
+++ b/src/components/Icon/Icon.react.js
@@ -9,12 +9,25 @@ type Props = {|
    * Should this icon be rendered within an <a> tag
    */
   +link?: boolean,
+  /**
+   * The icon prefix
+   */
   +prefix?: string,
+  /**
+   * The icon name
+   */
   +name: string,
   +isAriaHidden?: boolean,
+  /**
+   * Use the built in payment icon set
+   */
   +payment?: boolean,
 |};
 
+/**
+ * Display an icon.
+ * Uses the included feathers icon set by default but you can add your own
+ */
 function Icon({
   prefix: prefixFromProps = "fe",
   name,

--- a/src/components/Icon/Icon.react.js
+++ b/src/components/Icon/Icon.react.js
@@ -9,7 +9,7 @@ type Props = {|
    * Should this icon be rendered within an <a> tag
    */
   +link?: boolean,
-  +prefix?: "fa" | "fe" | "flag" | "payment",
+  +prefix?: string,
   +name: string,
   +isAriaHidden?: boolean,
   +payment?: boolean,

--- a/src/components/Icon/Icon.react.js
+++ b/src/components/Icon/Icon.react.js
@@ -19,9 +19,13 @@ type Props = {|
   +name: string,
   +isAriaHidden?: boolean,
   /**
-   * Use the built in payment icon set
+   * Use the built-in payment icon set
    */
   +payment?: boolean,
+  /**
+   * Use the built-in flag icon set
+   */
+  +flag?: boolean,
 |};
 
 /**
@@ -35,8 +39,9 @@ function Icon({
   link,
   isAriaHidden,
   payment,
+  flag,
 }: Props): React.Node {
-  const prefix = payment ? "payment" : prefixFromProps;
+  const prefix = (payment && "payment") || (flag && "flag") || prefixFromProps;
   const classes = cn(
     {
       [prefix]: true,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -6,6 +6,28 @@ module.exports = {
   },
   require: ["./src/Tabler.css"],
   styleguideDir: "./example/public/documentation",
+  template: {
+    head: {
+      links: [
+        {
+          rel: "stylesheet",
+          href:
+            "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css",
+        },
+        {
+          rel: "stylesheet",
+          href:
+            "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300i,400,400i,500,500i,600,600i,700,700i&amp;subset=latin-ext",
+        },
+      ],
+    },
+  },
+  theme: {
+    fontFamily: {
+      base:
+        '"Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif',
+    },
+  },
   sections: [
     {
       name: "Introduction",


### PR DESCRIPTION
Some small amends and docs improvements for Icons

- This updates the Icon docs to include font awesome instructions and flow type comments
- remove strict types on the Icon prefix prop
- Also adds a new `flag` prop that does exactly the same as the `payment` prop but for flags
- updates styleguide config so it loads fontawesome icons and google fonts