### PR TITLE
fix(DropdownMenu): performance issue 228

### DIFF
--- a/src/components/Dropdown/DropdownMenu.react.js
+++ b/src/components/Dropdown/DropdownMenu.react.js
@@ -41,7 +41,7 @@ function DropdownMenu({
   arrowPosition = "left",
   style,
   rootRef,
-  show,
+  show = false,
 }: Props): React.Node {
   const classes = cn(
     {
@@ -53,21 +53,22 @@ function DropdownMenu({
     className
   );
   return (
-    <Popper placement={position} eventsEnabled={true} positionFixed={false}>
-      {({ ref, style, placement, scheduleUpdate }: PopperChildrenProps) => {
-        scheduleUpdate();
-        return (
-          <div
-            className={classes}
-            data-placement={placement}
-            style={style}
-            ref={ref}
-          >
-            {children}
-          </div>
-        );
-      }}
-    </Popper>
+    show && (
+      <Popper placement={position} eventsEnabled={true} positionFixed={false}>
+        {({ ref, style, placement }: PopperChildrenProps) => {
+          return (
+            <div
+              className={classes}
+              data-placement={placement}
+              style={style}
+              ref={ref}
+            >
+              {children}
+            </div>
+          );
+        }}
+      </Popper>
+    )
   );
 }
 


### PR DESCRIPTION
Removes the callto scheduleUpdate and only renders the Popper if show
prop is true

Fixes #228

<!--

Thanks for submitting a pull request!

Please include a brief description and summarized list of your changes along with a screenshot of any visual changes.

And before you submit remember to:
- check the browser console for any errors
- make sure flow is giving the all clear
- add links to any related issues to this PR

-->
