### PR TITLE
fix(Tooltip): Fix non-existant Placement import

### DIFF
--- a/src/components/Tooltip/Tooltip.react.js
+++ b/src/components/Tooltip/Tooltip.react.js
@@ -2,8 +2,12 @@
 
 import * as React from "react";
 import cn from "classnames";
-import { Manager, Placement, Reference, Popper } from "react-popper";
-import type { PopperChildrenProps, ReferenceChildrenProps } from "react-popper";
+import { Manager, Reference, Popper } from "react-popper";
+import type {
+  Placement,
+  PopperChildrenProps,
+  ReferenceChildrenProps,
+} from "react-popper";
 import "./Tooltip.css";
 
 type Props = {|


### PR DESCRIPTION
Placement needs to be imported as a type. This fixes the non-existant import error during build.
