### PR TITLE
fix(): Actually run custom flow-copy-source script on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "precommit": "pretty-quick --staged && lint-staged && cd scripts && python propscheck.py && cd .. && ./scripts/runflow",
-    "flow:copy-source": "flow-copy-source -v src dist",
+    "flow:copy-source": "node scripts/flow-copy-source.js",
     "format": "prettier --write \"+(src|example)/**/*.js\"",
     "lint": "eslint --ext .js src/**/*",
     "styleguide": "styleguidist server",


### PR DESCRIPTION
I attempted to fix this in #235 but apparently made a mistake in the package.json scripts section. This PR causes the custom `flow-copy-source` script to actually run, fixing the original problem.