### PR TITLE
fix(NavItem): extend Component

### DIFF
--- a/src/components/Nav/NavItem.react.js
+++ b/src/components/Nav/NavItem.react.js
@@ -41,7 +41,7 @@ type State = {
 /**
  * A NavItem with react-popper powered subIems Dropdowns
  */
-class NavItem extends React.PureComponent<Props, State> {
+class NavItem extends React.Component<Props, State> {
   displayName = "Nav.Item";
 
   state = {


### PR DESCRIPTION
fix #226 by making `NavItem` extend Component instead of PureComponent