### PR TITLE
feat(): added colSpan to Table.Col (as in Table.ColHeader)

### DIFF
--- a/src/components/Table/TableCol.react.js
+++ b/src/components/Table/TableCol.react.js
@@ -6,6 +6,7 @@ import cn from "classnames";
 type Props = {|
   +children?: React.Node,
   +className?: string,
+  +colSpan?: number,
   +alignContent?: "left" | "center" | "right",
 |};
 
@@ -15,7 +16,7 @@ function TableCol({
   alignContent = "",
 }: Props): React.Node {
   const classes = cn({ [`text-${alignContent}`]: alignContent }, className);
-  return <td className={classes}>{children}</td>;
+  return <td className={classes} colSpan={colSpan}>{children}</td>;
 }
 
 TableCol.displayName = "Table.Col";


### PR DESCRIPTION
Table.Col is missing colSpan property, so I added it.

<!--

Thanks for submitting a pull request!

Please include a brief description and summarized list of your changes along with a screenshot of any visual changes.

And before you submit remember to:
- check the browser console for any errors
- make sure flow is giving the all clear
- add links to any related issues to this PR

-->
