### PR TITLE
fix(SiteFooter): removes unnecessary default value

### DIFF
--- a/src/components/Site/SiteFooter.react.js
+++ b/src/components/Site/SiteFooter.react.js
@@ -25,12 +25,7 @@ export type Props = {|
 /**
  * The footer of your website
  */
-const SiteFooter = ({
-  links = [],
-  note,
-  copyright,
-  nav,
-}: Props): React.Node => (
+const SiteFooter = ({ links, note, copyright, nav }: Props): React.Node => (
   <React.Fragment>
     {(links || note) && (
       <div className="footer">


### PR DESCRIPTION
Removes the default value for `links` in `SiteFooter` so it does not render an empty div when we don't provide a links array.
