### PR TITLE
fix(Dropdown): Match tabler behavior and close dropdown when item is …

### DIFF
--- a/src/components/Dropdown/Dropdown.react.js
+++ b/src/components/Dropdown/Dropdown.react.js
@@ -163,6 +163,16 @@ class Dropdown extends React.Component<Props, State> {
     this.setState(s => ({ isOpen: !s.isOpen }));
   };
 
+  _handleItemClick = (
+    e: SyntheticMouseEvent<HTMLElement>,
+    callback?: (SyntheticMouseEvent<*>) => mixed
+  ) => {
+    this.setState({ isOpen: false });
+    if (callback) {
+      callback(e);
+    }
+  };
+
   render(): React.Node {
     const {
       className,
@@ -234,7 +244,7 @@ class Dropdown extends React.Component<Props, State> {
                 key={i}
                 to={item.to}
                 RootComponent={item.RootComponent || itemsRootComponent}
-                onClick={item.onClick}
+                onClick={e => this._handleItemClick(e, item.onClick)}
               />
             )
         );


### PR DESCRIPTION
…clicked.

This resolves #296 and matches the default behavior by changing `isOpen` to `false` in `State` before calling the `onClick` callback for the individual item.
