### PR TITLE
fix(package): Fix win32 build error caused by posix-only command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "commitmsg": "commitlint -e $GIT_PARAMS",
-    "copytablercsstodist": "mkdir -p dist && cp src/Tabler.css src/Tabler.RTL.css dist/ && cp -r src/fonts src/images dist/",
+    "copytablercsstodist": "mkdir -p dist && shx cp src/Tabler.css src/Tabler.RTL.css dist/ && shx cp -r src/fonts src/images dist/",
     "cm": "git-cz",
-    "startagain": "rm -rf dist node_modules example/node_modules yarn.lock example/yarn.lock && yarn install && cd example && yarn install && cd .. && yarn build"
+    "startagain": "shx rm -rf dist node_modules example/node_modules yarn.lock example/yarn.lock && yarn install && cd example && yarn install && cd .. && yarn build"
   },
   "lint-staged": {
     "src/**/*.js": "eslint --max-warnings=0"
@@ -80,6 +80,7 @@
     "rollup-plugin-postcss": "1.6.2",
     "rollup-plugin-url": "2.0.1",
     "semantic-release": "^15.5.0",
+    "shx": "^0.3.2",
     "webpack": "4.19.1"
   },
   "files": [


### PR DESCRIPTION
Add SHX dependency to allow posix-only command such as `rm` and `cp` to be called in the build
process for win32 environments.

fix #347

<!--

Thanks for submitting a pull request!

Please include a brief description and summarized list of your changes along with a screenshot of any visual changes.

And before you submit remember to:
- check the browser console for any errors
- make sure flow is giving the all clear
- add links to any related issues to this PR

-->
