### PR TITLE
Notification tray mark all as read implementation

### DIFF
--- a/example/src/SiteWrapper.react.js
+++ b/example/src/SiteWrapper.react.js
@@ -165,10 +165,9 @@ const accountDropdownProps = {
 };
 
 class SiteWrapper extends React.Component<Props, State> {
-  constructor() {
-    super();
-    this.state = { unreadCount: 2 };
-  }
+  state = {
+    unreadCount: 2,
+  };
 
   render(): React.Node {
     const unreadCount = this.state.unreadCount || 0;

--- a/example/src/SiteWrapper.react.js
+++ b/example/src/SiteWrapper.react.js
@@ -16,6 +16,10 @@ type Props = {|
   +children: React.Node,
 |};
 
+type State = {|
+  +unreadCount: number,
+|};
+
 type subNavItem = {|
   +value: string,
   +to?: string,
@@ -160,8 +164,14 @@ const accountDropdownProps = {
   ],
 };
 
-class SiteWrapper extends React.Component<Props, void> {
+class SiteWrapper extends React.Component<Props, State> {
+  constructor() {
+    super();
+    this.state = { unreadCount: 2 };
+  }
+
   render(): React.Node {
+    const unreadCount = this.state.unreadCount || 0;
     return (
       <Site.Wrapper
         headerProps={{
@@ -182,7 +192,14 @@ class SiteWrapper extends React.Component<Props, void> {
               </Button>
             </Nav.Item>
           ),
-          notificationsTray: { notificationsObjects },
+          notificationsTray: {
+            notificationsObjects,
+            markAllAsRead: () =>
+              this.setState({ unreadCount: 0 }, () =>
+                setTimeout(() => this.setState({ unreadCount: 4 }), 5000)
+              ),
+            unread: unreadCount > 0,
+          },
           accountDropdown: accountDropdownProps,
         }}
         navProps={{ itemsObjects: navBarItems }}

--- a/src/components/Notification/NotificationTray.react.js
+++ b/src/components/Notification/NotificationTray.react.js
@@ -16,13 +16,17 @@ export type Props = {|
    * Display a small red circle to symbolize that there are unread notifications
    */
   +unread?: boolean,
+  /**
+   * Action to run when the 'Mark All As Read' button is activated
+   */
+  +markAllAsRead?: () => void,
 |};
 
 /**
  * An Icon triggered Dropdown containing Notifications
  */
 function NotificationTray(props: Props): React.Node {
-  const { children, unread, notificationsObjects } = props;
+  const { children, unread, notificationsObjects, markAllAsRead } = props;
   const notifications = children && React.Children.toArray(children);
   return (
     <Dropdown
@@ -52,10 +56,17 @@ function NotificationTray(props: Props): React.Node {
                   />
                 </Dropdown.Item>
               )))}
-          <Dropdown.ItemDivider />
-          <Dropdown.Item className="text-center text-muted-dark">
-            Mark all as read
-          </Dropdown.Item>
+          {markAllAsRead && (
+            <React.Fragment>
+              <Dropdown.ItemDivider />
+              <Dropdown.Item
+                className="text-center text-muted-dark"
+                onClick={() => markAllAsRead()}
+              >
+                Mark all as read
+              </Dropdown.Item>
+            </React.Fragment>
+          )}
         </React.Fragment>
       }
     />

--- a/src/components/Notification/NotificationTray.react.js
+++ b/src/components/Notification/NotificationTray.react.js
@@ -56,7 +56,7 @@ function NotificationTray(props: Props): React.Node {
                   />
                 </Dropdown.Item>
               )))}
-          {markAllAsRead && (
+          {markAllAsRead && unread && (
             <React.Fragment>
               <Dropdown.ItemDivider />
               <Dropdown.Item


### PR DESCRIPTION
This pull request adds the ability to provide a callback so the application can resolve unread notifications when the 'mark all as read' button is clicked.

As part of this implementation the 'mark all as read' button is removed if there are no unread messages.

Demo application was updated to show unread notifications on start, then when the 'mark all read' button is activated, sets the flag to set unread to false, and then sets a timeout for 5 seconds to set unread to true again.

<img width="529" alt="screen shot 2018-11-24 at 10 07 23 am" src="https://user-images.githubusercontent.com/1893056/48962810-58b10680-efd1-11e8-97a5-af030dc42f2b.png">

<img width="525" alt="screen shot 2018-11-24 at 10 07 30 am" src="https://user-images.githubusercontent.com/1893056/48962812-5c448d80-efd1-11e8-9536-96744f16211c.png">
