### PR TITLE
chore(vim): Add vim temp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ yarn-error.log*
 
 # VSCode
 .vscode
+
+# vim
+*.swp
+


### PR DESCRIPTION
Adds *.swp to the .gitignore file to make it easier to work with vim