### PR TITLE
Form.InputGroupText

### DIFF
--- a/example/src/FormElementsPage.react.js
+++ b/example/src/FormElementsPage.react.js
@@ -529,7 +529,9 @@ function FormElements() {
             <ComponentDemo>
               <Form.Group label="Username">
                 <Form.InputGroup>
-                  <Form.InputGroupPrepend>@</Form.InputGroupPrepend>
+                  <Form.InputGroupPrepend>
+                    <Form.InputGroupText>@</Form.InputGroupText>
+                  </Form.InputGroupPrepend>
                   <Form.Input placeholder="Username" />
                 </Form.InputGroup>
               </Form.Group>
@@ -539,7 +541,9 @@ function FormElements() {
               <Form.Group label="Subdomain">
                 <Form.InputGroup>
                   <Form.Input placeholder="Your subdomain" />
-                  <Form.InputGroupAppend>.example.com</Form.InputGroupAppend>
+                  <Form.InputGroupAppend>
+                    <Form.InputGroupText>.example.com</Form.InputGroupText>
+                  </Form.InputGroupAppend>
                 </Form.InputGroup>
               </Form.Group>
             </ComponentDemo>
@@ -548,7 +552,9 @@ function FormElements() {
               <Form.Group label="Your vanity URL">
                 <Form.InputGroup>
                   <Form.InputGroupPrepend>
-                    https://example.com/users/
+                    <Form.InputGroupText>
+                      https://example.com/users/
+                    </Form.InputGroupText>
                   </Form.InputGroupPrepend>
                   <Form.Input />
                 </Form.InputGroup>
@@ -558,9 +564,13 @@ function FormElements() {
             <ComponentDemo>
               <Form.Group label="Price">
                 <Form.InputGroup>
-                  <Form.InputGroupPrepend>$</Form.InputGroupPrepend>
+                  <Form.InputGroupPrepend>
+                    <Form.InputGroupText>$</Form.InputGroupText>
+                  </Form.InputGroupPrepend>
                   <Form.Input />
-                  <Form.InputGroupAppend>.00</Form.InputGroupAppend>
+                  <Form.InputGroupAppend>
+                    <Form.InputGroupText>.00</Form.InputGroupText>
+                  </Form.InputGroupAppend>
                 </Form.InputGroup>
               </Form.Group>
             </ComponentDemo>

--- a/src/components/Form/Form.react.js
+++ b/src/components/Form/Form.react.js
@@ -25,6 +25,7 @@ import FormSwitchStack from "./FormSwitchStack.react";
 import FormSwitch from "./FormSwitch.react";
 import FormInputGroupAppend from "./FormInputGroupAppend.react";
 import FormInputGroupPrepend from "./FormInputGroupPrepend.react";
+import FormInputGroupText from "./FormInputGroupText.react";
 import FormMaskedInput from "./FormMaskedInput.react";
 import FormDatePicker from "./FormDatePicker.react";
 
@@ -88,6 +89,7 @@ Form.SwitchStack = FormSwitchStack;
 Form.Switch = FormSwitch;
 Form.InputGroupAppend = FormInputGroupAppend;
 Form.InputGroupPrepend = FormInputGroupPrepend;
+Form.InputGroupText = FormInputGroupText;
 Form.MaskedInput = FormMaskedInput;
 Form.DatePicker = FormDatePicker;
 

--- a/src/components/Form/FormInputGroupText.react.js
+++ b/src/components/Form/FormInputGroupText.react.js
@@ -1,0 +1,18 @@
+// @flow
+
+import * as React from "react";
+import cn from "classnames";
+
+type Props = {|
+  +children?: React.Node,
+  +className?: string,
+|};
+
+function FormInputGroupText({ className, children }: Props): React.Node {
+  const classes = cn("input-group-text", className);
+  return <span className={classes}>{children}</span>;
+}
+
+FormInputGroupText.displayName = "Form.InputGroupText";
+
+export default FormInputGroupText;


### PR DESCRIPTION
Added the following as a component, named `InputGroupText` and added it to the `InputGroupPrepend` and `InputGroupAppend` demos to fix a display bug:

`<span class="input-group-text">...</span>`

https://i.gyazo.com/cf794a25e70397acb4239ced1196e94c.png
https://i.gyazo.com/9e1a59bc7aa688dcf07d42a330fa016c.png
