### PR TITLE
feat(FileInput): add accept property

### DIFF
--- a/src/components/Form/FormFileInput.react.js
+++ b/src/components/Form/FormFileInput.react.js
@@ -21,6 +21,7 @@ type Props = {|
   +label?: string,
   +disabled?: boolean,
   +readOnly?: boolean,
+  +accept?: string,
 |};
 
 type State = {| fileName: string |};
@@ -52,6 +53,7 @@ class FormFileInput extends React.Component<Props, State> {
       onPointerLeave,
       onFocus,
       onBlur,
+      accept,
     } = this.props;
 
     const classes = cn("custom-file", className);
@@ -73,6 +75,7 @@ class FormFileInput extends React.Component<Props, State> {
           onPointerLeave={onPointerLeave}
           onFocus={onFocus}
           onBlur={onBlur}
+          accept={accept}
         />
         <label
           className="custom-file-label"


### PR DESCRIPTION
Added support for ["accept" property of input[type=file]](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#attr-accept) in FileInput

Related Issue: [#418](https://github.com/tabler/tabler-react/issues/418)
<!--

Thanks for submitting a pull request!

Please include a brief description and summarized list of your changes along with a screenshot of any visual changes.

And before you submit remember to:
- check the browser console for any errors
- make sure flow is giving the all clear
- add links to any related issues to this PR

-->
