### PR TITLE
fix(text-decoration-skip) - Replace text-decoration-skip: ink to text-decoration-skip-ink: auto, because spec had been changed

### DIFF
--- a/src/Tabler.css
+++ b/src/Tabler.css
@@ -9935,8 +9935,8 @@ body *:hover::-webkit-scrollbar-thumb {
 }
 
 a {
-  -webkit-text-decoration-skip: ink;
-  text-decoration-skip: ink;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
 }
 
 h1 a,


### PR DESCRIPTION
This will fix this eslint warning 

```
Compiled with warnings.

./node_modules/tabler-react/dist/Tabler.css (./node_modules/css-loader??ref--6-oneOf-3-1!./node_modules/postcss-loader/src??postcss!./node_modules/tabler-react/dist/Tabler.css)
Warning

(9939:3) Replace text-decoration-skip: ink to text-decoration-skip-ink: auto, because spec had been changed

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
```

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip

<!--

Thanks for submitting a pull request!

Please include a brief description and summarized list of your changes along with a screenshot of any visual changes.

And before you submit remember to:
- check the browser console for any errors
- make sure flow is giving the all clear
- add links to any related issues to this PR

-->
