### PR TITLE
fix(css): Update RTL version of CSS to have fix included in #420

### DIFF
--- a/src/Tabler.RTL.css
+++ b/src/Tabler.RTL.css
@@ -10282,8 +10282,8 @@ body *:hover::-webkit-scrollbar-thumb {
 }
 
 a {
-  -webkit-text-decoration-skip: ink;
-  text-decoration-skip: ink;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
 }
 
 h1 a,


### PR DESCRIPTION
In https://github.com/tabler/tabler-react/pull/420 `text-decoration-skip: ink` was changed to `text-decoration-skip-ink: auto` but this was not applied to the RTL version of the CSS. 

This PR makes that change.

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip-ink

https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip