### PR TITLE
Edit to <Table.Header> example

### DIFF
--- a/src/components/Table/TableHeader.examples.md
+++ b/src/components/Table/TableHeader.examples.md
@@ -1,9 +1,11 @@
 ```jsx
 <Table>
   <Table.Header>
-    <Table.ColHeader>ID</Table.ColHeader>
-    <Table.ColHeader>Name</Table.ColHeader>
-    <Table.ColHeader>Action</Table.ColHeader>
+    <Table.Row>
+      <Table.ColHeader>ID</Table.ColHeader>
+      <Table.ColHeader>Name</Table.ColHeader>
+      <Table.ColHeader>Action</Table.ColHeader>
+    </Table.Row>
   </Table.Header>
 </Table>
 ```


### PR DESCRIPTION
I found that the docs were missing a <Table.Row> declaration, which led to warnings on my dev server during compile. I've added these and hopefully you can just pull into the repo to help others.