### PR TITLE
Remove demo imageURL for LoginPage

### DIFF
--- a/src/page_templates/account/LoginPage/LoginPage.react.js
+++ b/src/page_templates/account/LoginPage/LoginPage.react.js
@@ -44,10 +44,11 @@ function LoginPage(props: Props): React.Node {
     values,
     strings = {},
     errors,
+    imageURL,
   } = props;
 
   return (
-    <StandaloneFormPage imageURL={"./demo/logo.svg"}>
+    <StandaloneFormPage imageURL={imageURL}>
       <FormCard
         buttonText={strings.buttonText || defaultStrings.buttonText}
         title={strings.title || defaultStrings.title}


### PR DESCRIPTION
The LoginPage logo should be set by a prop. It should not be the demo logo.