### PR TITLE
createFactory deprecation warning fix. See post https://blogreact.com…

### DIFF
--- a/src/components/Nav/Nav.react.js
+++ b/src/components/Nav/Nav.react.js
@@ -101,9 +101,13 @@ class Nav extends React.Component<Props, State> {
 
     let element: ?React.Element<*> = null;
     if (routerContextComponentType) {
-      const routerContextComponentFactory = React.createFactory(
+      
+      let createFactory = type => React.createElement.bind(null, type);
+
+      const routerContextComponentFactory = createFactory(
         routerContextComponentType
       );
+
       element = routerContextComponentFactory({
         callback: this.routerCallback,
       });


### PR DESCRIPTION
…/react-v16-13-0/

createFactory deprecation warning fix.

Browser is showing warning:

React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.

As the warning states - React.createFactory() will be **removed** in a future release. 

See post https://blogreact.com/react-v16-13-0/ for more info. 
